### PR TITLE
Enable Drone CI builds for tags and latest (master)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,58 @@
+---
+kind: pipeline
+type: docker
+name: release-latest
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  branch:
+  - master
+  event:
+    exclude:
+    - pull_request
+    - tag
+    - promote
+    - rollback
+
+steps:
+- name: publish-docker-wopi-latest
+  pull: always
+  image: plugins/docker
+  settings:
+    repo: cs3org/wopiserver
+    tags: latest
+    dockerfile: wopiserver.Dockerfile
+    username:
+      from_secret: dockerhub_username
+    password:
+      from_secret: dockerhub_password
+
+---
+kind: pipeline
+type: docker
+name: release
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    include:
+    - tag
+
+steps:
+- name: publish-docker-wopi-tag
+  pull: always
+  image: plugins/docker
+  settings:
+    repo: cs3org/wopiserver
+    tags: ${DRONE_TAG}
+    dockerfile: wopiserver.Dockerfile
+    username:
+      from_secret: dockerhub_username
+    password:
+      from_secret: dockerhub_password


### PR DESCRIPTION
Create `release` & `release-latest` pipelines so we can push and use images from https://hub.docker.com/r/cs3org/wopiserver 

@glpatcern could you give a smoke test to the _freshly-baked_ `cs3org/wopiserver:latest` image to see if it built properly on my fork's [drone](https://cloud.drone.io/SamuAlfageme/wopiserver/3/1/2)? 

This closes https://github.com/sciencemesh/sciencemesh/issues/63