### PR TITLE
Interop locking enhancements for OnlyOffice

### DIFF
--- a/cernbox-wopi-server.spec
+++ b/cernbox-wopi-server.spec
@@ -4,7 +4,7 @@
 Name:      cernbox-wopi-server
 Summary:   A WOPI server to support Office online suites for the ScienceMesh IOP
 Version:   5.0
-Release:   0%{?dist}
+Release:   1%{?dist}
 License:   GPLv3
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     CERN-IT/ST

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -24,6 +24,7 @@ import json
 import wopiutils as utils
 try:
   import flask                   # Flask app server, python3-flask-0.12.2 + python3-pyOpenSSL-17.3.0
+  from werkzeug.exceptions import HTTPException
   import jwt                     # PyJWT JSON Web Token, python3-jwt-1.6.1 or above
 except ImportError:
   print("Missing modules, please install Flask and JWT with `pip3 install flask PyJWT pyOpenSSL`")
@@ -217,6 +218,12 @@ class Wopi:
 #
 # The Flask web application starts here
 #
+@Wopi.app.errorhandler(HTTPException)
+def handleException(e):
+  '''Generic method to log any uncaught exception'''
+  return utils.logGeneralExceptionAndReturn(e, flask.request)
+
+
 @Wopi.app.route("/", methods=['GET'])
 def index():
   '''Return a default index page with some user-friendly information about this service'''


### PR DESCRIPTION
As agreed with @diocas, with this PR we return the lock initial creation timestamp on `/wopi/cbox/lock` (both on POST and on GET).

This is to meet the OnlyOffice requirement that "Every time the document is edited and saved, the key must be generated anew", but the document's key must persist any intermediate save operation. Therefore, the key's lifetime exactly matches the interop/wopi lock lifetime.