### PR TITLE
Provide a `/wopi/iop/open` endpoint

### DIFF
--- a/cernbox-wopi-server.spec
+++ b/cernbox-wopi-server.spec
@@ -3,8 +3,8 @@
 #
 Name:      cernbox-wopi-server
 Summary:   A WOPI server to support Office online suites for the ScienceMesh IOP
-Version:   5.0
-Release:   1%{?dist}
+Version:   5.1
+Release:   0%{?dist}
 License:   GPLv3
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     CERN-IT/ST
@@ -79,6 +79,10 @@ touch /etc/wopi/iopsecret
 %_python_lib/*
 
 %changelog
+* Mon Jun 15 2020 Giuseppe Lo Presti <lopresti@cern.ch> 5.1
+- Expose a new /wopi/iop/open endpoint to match Reva. The
+  former /wopi/cbox/open endpoint is deprecated and will
+  be dropped once production moves forward.
 * Fri Jun  5 2020 Giuseppe Lo Presti <lopresti@cern.ch> 5.0
 - General refactoring of the code base and evolution to become
   fully vendor-neutral: see https://github.com/cs3org/wopiserver/pull/14

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -328,18 +328,17 @@ def iopGetOpenFiles():
   '''Returns a list of all currently opened files, for operations purposes only.
   This call is protected by the same shared secret as the /wopi/iop/open call.'''
   req = flask.request
-  # first check if the shared secret matches ours
   if 'Authorization' not in req.headers or req.headers['Authorization'] != 'Bearer ' + Wopi.iopsecret:
     Wopi.log.warning('msg="iopGetOpenFiles: unauthorized access attempt, missing authorization token" ' \
                      'client="%s"' % req.remote_addr)
     return 'Client not authorized', http.client.UNAUTHORIZED
   # first convert the sets into lists, otherwise sets cannot be serialized in JSON format
-  jl = {}
+  jlist = {}
   for f in list(Wopi.openfiles.keys()):
-    jl[f] = (Wopi.openfiles[f][0], tuple(Wopi.openfiles[f][1]))
+    jlist[f] = (Wopi.openfiles[f][0], tuple(Wopi.openfiles[f][1]))
   # dump the current list of opened files in JSON format
   Wopi.log.info('msg="iopGetOpenFiles: returning list of open files" client="%s"' % req.remote_addr)
-  return flask.Response(json.dumps(jl), mimetype='application/json')
+  return flask.Response(json.dumps(jlist), mimetype='application/json')
 
 
 @Wopi.app.route("/wopi/cbox/download", methods=['GET'])

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -307,7 +307,7 @@ def iopOpen():
             return '%s&access_token=%s' % (utils.generateWopiSrc(inode), acctok)      # no need to URL-encode the JWT token
           except IOError as e:
             Wopi.log.info('msg="cboxOpen: remote error on generating token" client="%s" user="%s" ' \
-                          'friendlyname="%s" viewmode="%s" endpoint="%s" reason="%s"' % \
+                          'friendlyname="%s" mode="%s" endpoint="%s" reason="%s"' % \
                           (req.remote_addr, userid, username, viewmode, endpoint, e))
             return 'Remote error or file not found', http.client.NOT_FOUND
     except socket.gaierror:
@@ -822,7 +822,7 @@ def wopiPutRelative(fileid, reqheaders, acctok):
     return 'I/O Error', http.client.INTERNAL_SERVER_ERROR
   # generate an access token for the new file
   Wopi.log.info('msg="PutRelative: generating new access token" user="%s" filename="%s" ' \
-                'viewmode="ViewMode.READ_WRITE" friendlyname="%s"' % \
+                'mode="ViewMode.READ_WRITE" friendlyname="%s"' % \
                 (acctok['userid'], targetName, acctok['username']))
   inode, newacctok = utils.generateAccessToken(acctok['userid'], targetName, utils.ViewMode.READ_WRITE, acctok['username'], \
                                                acctok['folderurl'], acctok['endpoint'])

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -259,12 +259,11 @@ def iopOpen():
   - string endpoint (optional): the storage endpoint to be used to look up the file or the storage id, in case of
     multi-instance underlying storage; defaults to 'default'
   Note: this is the most sensitive call of this WOPI server as it provides direct
-  access to any user's file, therefore it is protected both by IP and a shared secret. The shared
-  secret protection is disabled when running in plain http mode for testing purposes.'''
+  access to any user's file, therefore it is protected both by IP and a shared secret.'''
   Wopi.refreshconfig()
   req = flask.request
   # if running in https mode, first check if the shared secret matches ours
-  if Wopi.useHttps and ('Authorization' not in req.headers or req.headers['Authorization'] != 'Bearer ' + Wopi.iopsecret):
+  if 'Authorization' not in req.headers or req.headers['Authorization'] != 'Bearer ' + Wopi.iopsecret:
     Wopi.log.warning('msg="cboxOpen: unauthorized access attempt, missing authorization token" ' \
                      'client="%s"' % req.remote_addr)
     return 'Client not authorized', http.client.UNAUTHORIZED
@@ -281,7 +280,7 @@ def iopOpen():
       if ruid == 0 or rgid == 0:
         raise ValueError
   except ValueError:
-    Wopi.log.warning('msg="cboxOpen: invalid user/group in request" client="%s" user="%s"' % \
+    Wopi.log.warning('msg="cboxOpen: invalid or missing user/token in request" client="%s" user="%s"' % \
                      (req.remote_addr, userid))
     return 'Client not authorized', http.client.UNAUTHORIZED
   # then resolve the client and reject unauthorized ones

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -112,7 +112,7 @@ def generateAccessToken(userid, fileid, viewmode, username, folderurl, endpoint)
       except IOError:
         pass
   exptime = int(time.time()) + _ctx['wopi'].tokenvalidity
-  acctok = jwt.encode({'userid': userid, 'filename': filename, 'username': username, 'viewmode': viewmode,
+  acctok = jwt.encode({'userid': userid, 'filename': filename, 'username': username, 'viewmode': viewmode.value,
                        'extlock': locked, 'folderurl': folderurl, 'exp': exptime, 'endpoint': endpoint}, \
                       _ctx['wopi'].wopisecret, algorithm='HS256').decode('UTF-8')
   _ctx['log'].info('msg="Access token generated" userid="%s" mode="%s" filename="%s" inode="%s" ' \

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -11,7 +11,7 @@ import traceback
 import hashlib
 import json
 import urllib.parse
-from enum import IntEnum
+from enum import Enum
 import http.client
 import flask
 import jwt
@@ -21,17 +21,16 @@ import jwt
 _ctx = {}
 
 
-class ViewMode(IntEnum):
+class ViewMode(Enum):
   '''File view mode: reference is
   https://github.com/cs3org/cs3apis/blob/master/cs3/app/provider/v1beta1/provider_api.proto#L79
   '''
-  INVALID = 0
   # The file can be opened but not downloaded
-  VIEW_ONLY = 1
+  VIEW_ONLY = "VIEW_MODE_VIEW_ONLY"
   # The file can be downloaded
-  READ_ONLY = 2
+  READ_ONLY = "VIEW_MODE_READ_ONLY"
   # The file can be downloaded and updated
-  READ_WRITE = 3
+  READ_WRITE = "VIEW_MODE_READ_WRITE"
 
 
 def init(storage, wopiserver):

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -11,7 +11,7 @@ import traceback
 import hashlib
 import json
 import urllib.parse
-from enum import Enum
+from enum import IntEnum
 import http.client
 import flask
 import jwt
@@ -21,7 +21,7 @@ import jwt
 _ctx = {}
 
 
-class ViewMode(Enum):
+class ViewMode(IntEnum):
   '''File view mode: reference is
   https://github.com/cs3org/cs3apis/blob/master/cs3/app/provider/v1beta1/provider_api.proto#L79
   '''
@@ -116,7 +116,7 @@ def generateAccessToken(userid, fileid, viewmode, username, folderurl, endpoint)
   acctok = jwt.encode({'userid': userid, 'filename': filename, 'username': username, 'viewmode': viewmode,
                        'extlock': locked, 'folderurl': folderurl, 'exp': exptime, 'endpoint': endpoint}, \
                       _ctx['wopi'].wopisecret, algorithm='HS256').decode('UTF-8')
-  _ctx['log'].info('msg="Access token generated" userid="%s" viewmode="%s" filename="%s" inode="%s" ' \
+  _ctx['log'].info('msg="Access token generated" userid="%s" mode="%s" filename="%s" inode="%s" ' \
                    'mtime="%s" folderurl="%s" expiration="%d" token="%s"' % \
                    (userid, viewmode, filename, statInfo['inode'], statInfo['mtime'], folderurl, exptime, acctok[-20:]))
   # return the inode == fileid and the access token

--- a/test/wopiserver-test.conf
+++ b/test/wopiserver-test.conf
@@ -1,7 +1,6 @@
 [general]
 storagetype = local
 port = 8880
-allowedclients = localhost
 
 [security]
 usehttps = no

--- a/tools/wopilistopenfiles.sh
+++ b/tools/wopilistopenfiles.sh
@@ -1,2 +1,2 @@
-curl --header "Authorization: Bearer "`cat /etc/wopi/iopsecret` https://`hostname`:8443/wopi/cbox/open/list
+curl --header "Authorization: Bearer "`cat /etc/wopi/iopsecret` https://`hostname`:8443/wopi/iop/open/list
 echo

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -12,24 +12,21 @@ from wopiutils import ViewMode
 # usage function
 def usage(exitcode):
   '''Prints usage'''
-  print('Usage : ' + sys.argv[0] + ' [-h|--help] [-m|--mode 1|2|3] <filename> <uid> <gid>')
+  print('Usage : ' + sys.argv[0] + ' [-h|--help] [-v|--viewmode 1|2|3] <filename> <uid> <gid>')
   sys.exit(exitcode)
 
 # first parse the options
 try:
-  options, args = getopt.getopt(sys.argv[1:], 'hvm:', ['help', 'verbose', 'mode'])
+  options, args = getopt.getopt(sys.argv[1:], 'hv:', ['help', 'viewmode'])
 except getopt.GetoptError as e:
   print(e)
   usage(1)
-verbose = False
-mode = ViewMode.READ_WRITE
+viewmode = ViewMode.READ_WRITE
 for f, v in options:
   if f == '-h' or f == '--help':
     usage(0)
-  elif f == '-v' or f == '--verbose':
-    verbose = True
-  elif f == '-m' or f == '--mode':
-    mode = v
+  elif f == '-v' or f == '--viewmode':
+    viewmode = v
   else:
     print("unknown option : " + f)
     usage(1)
@@ -72,14 +69,14 @@ apps = requests.get(wopiurl + '/wopi/cbox/endpoints', verify=False).json()
 wopisrc = requests.get(wopiurl + '/wopi/iop/open', verify=False,
                        headers={'Authorization': 'Bearer ' + iopsecret},
                        params={'ruid': ruid, 'rgid': rgid, 'filename': filename, 'endpoint': endpoint,
-                               'viewmode': mode, 'username': 'Operator', 'folderurl': 'foo'})
+                               'viewmode': viewmode, 'username': 'Operator', 'folderurl': 'foo'})
 if wopisrc.status_code != 200:
   print('WOPI open request failed:\n%s' % wopisrc.content.decode())
   sys.exit(-1)
 
 # return the full URL to the user
 try:
-  url = apps[os.path.splitext(filename)[1]]['edit' if mode == ViewMode.READ_WRITE else 'view']
+  url = apps[os.path.splitext(filename)[1]]['edit' if viewmode == ViewMode.READ_WRITE else 'view']
   url += '?' if '?' not in url else '&'
   print('App URL:\n%sWOPISrc=%s\n' % (url, wopisrc.content.decode()))
 except KeyError:

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 '''
-Call the /wopi/cbox/open REST API on the given file and return a URL for direct editing it
+Call the /wopi/iop/open REST API on the given file and return a URL for direct editing it
 
 Author: Giuseppe.LoPresti@cern.ch
 CERN IT/ST
@@ -65,7 +65,7 @@ requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.
 apps = requests.get(wopiurl + '/wopi/cbox/endpoints', verify=False).json()
 
 # open the file and get WOPI token
-wopisrc = requests.get(wopiurl + '/wopi/cbox/open', verify=False,
+wopisrc = requests.get(wopiurl + '/wopi/iop/open', verify=False,
                        headers={'Authorization': 'Bearer ' + iopsecret},
                        params={'ruid': ruid, 'rgid': rgid, 'filename': filename, 'endpoint': endpoint,
                                'canedit': 'True', 'username': 'Operator', 'folderurl': 'foo'})

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -7,6 +7,7 @@ CERN IT/ST
 '''
 
 import sys, os, getopt, configparser, requests
+from wopiutils import ViewMode
 
 # usage function
 def usage(exitcode):
@@ -21,7 +22,7 @@ except getopt.GetoptError as e:
   print(e)
   usage(1)
 verbose = False
-mode = 3   # 3 is full access, 2 for read-only, 1 for view-only.
+mode = ViewMode.READ_WRITE
 for f, v in options:
   if f == '-h' or f == '--help':
     usage(0)

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -21,7 +21,7 @@ try:
 except getopt.GetoptError as e:
   print(e)
   usage(1)
-viewmode = ViewMode.READ_WRITE
+viewmode = int(ViewMode.READ_WRITE)
 for f, v in options:
   if f == '-h' or f == '--help':
     usage(0)

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -79,7 +79,7 @@ if wopisrc.status_code != 200:
 
 # return the full URL to the user
 try:
-  url = apps[os.path.splitext(filename)[1]]['edit']
+  url = apps[os.path.splitext(filename)[1]]['edit' if mode == ViewMode.READ_WRITE else 'view']
   url += '?' if '?' not in url else '&'
   print('App URL:\n%sWOPISrc=%s\n' % (url, wopisrc.content.decode()))
 except KeyError:

--- a/tools/wopiopen.py
+++ b/tools/wopiopen.py
@@ -11,21 +11,24 @@ import sys, os, getopt, configparser, requests
 # usage function
 def usage(exitcode):
   '''Prints usage'''
-  print('Usage : ' + sys.argv[0] + ' [-h|--help] <filename> <uid> <gid>')
+  print('Usage : ' + sys.argv[0] + ' [-h|--help] [-m|--mode 1|2|3] <filename> <uid> <gid>')
   sys.exit(exitcode)
 
 # first parse the options
 try:
-  options, args = getopt.getopt(sys.argv[1:], 'hv', ['help', 'verbose'])
+  options, args = getopt.getopt(sys.argv[1:], 'hvm:', ['help', 'verbose', 'mode'])
 except getopt.GetoptError as e:
   print(e)
   usage(1)
 verbose = False
+mode = 3   # 3 is full access, 2 for read-only, 1 for view-only.
 for f, v in options:
   if f == '-h' or f == '--help':
     usage(0)
   elif f == '-v' or f == '--verbose':
     verbose = True
+  elif f == '-m' or f == '--mode':
+    mode = v
   else:
     print("unknown option : " + f)
     usage(1)
@@ -68,7 +71,7 @@ apps = requests.get(wopiurl + '/wopi/cbox/endpoints', verify=False).json()
 wopisrc = requests.get(wopiurl + '/wopi/iop/open', verify=False,
                        headers={'Authorization': 'Bearer ' + iopsecret},
                        params={'ruid': ruid, 'rgid': rgid, 'filename': filename, 'endpoint': endpoint,
-                               'canedit': 'True', 'username': 'Operator', 'folderurl': 'foo'})
+                               'viewmode': mode, 'username': 'Operator', 'folderurl': 'foo'})
 if wopisrc.status_code != 200:
   print('WOPI open request failed:\n%s' % wopisrc.content.decode())
   sys.exit(-1)

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -28,9 +28,6 @@ port = 8880
 # URL of your WOPI server or your HA proxy in front of it
 #wopiurl = https://your-wopi-server.org:8443
 
-# List of FQDNs that are allowed to generate access tokens; LB aliases are supported
-#allowedclients = your-oc-server.org
-
 # URL for direct download of files. The complete URL that is sent
 # to clients will include the access_token argument
 #downloadurl = https://your-wopi-server.org/wopi/cbox/download


### PR DESCRIPTION
To match https://github.com/cs3org/cs3apis/pull/75, this implements a new `/wopi/iop/open` endpoint with the following arguments:
Required headers:
  - `Authorization: Bearer` and the shared Reva/WOPI secret
  - `TokenHeader`: an x-access-token to serve as user identity towards Reva

Query parameters:
  - string viewmode: how the user should access the file - one of `VIEW_MODE_VIEW_ONLY`, `VIEW_MODE_READ_ONLY`, `VIEW_MODE_READ_WRITE`, defaults to `VIEW_MODE_READ_ONLY`
  - string username (optional): user's full display name, typically shown by the Office app
  - string filename OR fileid: the full path of the filename to be opened, or its fileid
  - string folderurl: the URL to come back to the containing folder for this file, typically shown by the Office app
  - string endpoint (optional): the storage endpoint to be used to look up the file or the storage id, in case of multi-instance underlying storage; defaults to 'default'

The former whitelist mechanism is dropped, given the double protection provided by the required headers.