### PR TITLE
Add support for atomic locking

### DIFF
--- a/cernbox-wopi-server.spec
+++ b/cernbox-wopi-server.spec
@@ -4,7 +4,7 @@
 Name:      cernbox-wopi-server
 Summary:   A WOPI server to support Office online suites for the ScienceMesh IOP
 Version:   %{_version}
-Release:   1%{?dist}
+Release:   0%{?dist}
 License:   GPLv3
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     CERN-IT/ST
@@ -79,6 +79,11 @@ touch /etc/wopi/iopsecret
 %_python_lib/*
 
 %changelog
+* Wed Aug 26 2020 Giuseppe Lo Presti <lopresti@cern.ch> 5.4
+- Make CS3-based uploads work with tus and through gateway
+- Fixed race condition in cboxLock
+- Delay lock checks when needed (i.e. in WOPI LOCK), not
+  at access token creation time
 * Tue Aug  4 2020 Giuseppe Lo Presti <lopresti@cern.ch> 5.3
 - Fixed CS3-based workflows: the wopiopen.py tool and the
   open-file-in-app-provider reva command both support

--- a/src/cs3iface.py
+++ b/src/cs3iface.py
@@ -172,10 +172,12 @@ def readfile(_endpoint, filepath, userid):
       yield data[i:i+ctx['chunksize']]
 
 
-def writefile(_endpoint, filepath, userid, content, _noversion=0):
+def writefile(_endpoint, filepath, userid, content, _noversion=0, nooverwrite=0):
   '''Write a file using the given userid as access token. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
-    The noversion flag is currently not supported.'''
+    The noversion and nooverwrite flags are currently not supported.'''
+  if nooverwrite == 1:
+    ctx['log'].warning('msg="No-overwrite flag not yet supported, going for standard Upload"')
   tstart = time.time()
   # prepare endpoint
   if isinstance(content, str):

--- a/src/cs3iface.py
+++ b/src/cs3iface.py
@@ -172,12 +172,13 @@ def readfile(_endpoint, filepath, userid):
       yield data[i:i+ctx['chunksize']]
 
 
-def writefile(_endpoint, filepath, userid, content, _noversion=0, nooverwrite=0):
+def writefile(_endpoint, filepath, userid, content, islock=False):
   '''Write a file using the given userid as access token. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
-    The noversion and nooverwrite flags are currently not supported.'''
-  if nooverwrite == 1:
-    ctx['log'].warning('msg="No-overwrite flag not yet supported, going for standard Upload"')
+    The islock flag is currently not supported. TODO the backend should at least support
+    writing the file with O_CREAT|O_EXCL flags to prevent races.'''
+  if islock:
+    ctx['log'].warning('msg="Lock (no-overwrite) flag not yet supported, going for standard upload"')
   tstart = time.time()
   # prepare endpoint
   if isinstance(content, str):

--- a/src/cs3iface.py
+++ b/src/cs3iface.py
@@ -210,7 +210,8 @@ def writefile(_endpoint, filepath, userid, content, islock=False):
   if putres.status_code != http.client.OK:
     ctx['log'].error('msg="Error uploading file to Reva" code="%d" reason="%s"' % (putres.status_code, putres.reason))
     raise IOError(putres.reason)
-  ctx['log'].info('msg="File open for write" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
+  ctx['log'].info('msg="File written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' % \
+                  (filepath, (tend-tstart)*1000, islock))
 
 
 def renamefile(_endpoint, filepath, newfilepath, userid):

--- a/src/localiface.py
+++ b/src/localiface.py
@@ -157,6 +157,23 @@ def writefile(_endpoint, filepath, _userid, content, islock=False):
     log.warning('msg="Error writing to file" filepath="%s" error="%s"' % (filepath, e))
     raise IOError(e)
 
+def openfileexcl(_endpoint, filepath, _userid, content):
+  if isinstance(content, str):
+    content = bytes(content, 'UTF-8')
+  size = len(content)
+  filepath = _getfilepath(filepath)
+  log.debug('msg="Invoking openfileexcl" filepath="%s" size="%d"' % (filepath, size))
+  tstart = time.time()
+  fd = 0
+  try:
+    fd = os.open(filepath, os.O_CREAT | os.O_EXCL)   # no O_BINARY in Linux
+    f = os.fdopen(fd, mode='wb')
+  except FileExistsError:
+    log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
+    raise IOError('File exists and islock flag requested')
+  tend = time.time()
+  log.info('msg="openfileexcl completed, file left open" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
+
 
 def renamefile(_endpoint, origfilepath, newfilepath, _userid):
   '''Rename a file from origfilepath to newfilepath on behalf of the given userid.'''

--- a/src/localiface.py
+++ b/src/localiface.py
@@ -144,7 +144,6 @@ def writefile(_endpoint, filepath, _userid, content, islock=False):
       log.warning('msg="Error opening file for write" filepath="%s" error="%s"' % (filepath, e))
       raise IOError(e)
   tend = time.time()
-  log.info('msg="File open for write" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
   try:
     written = f.write(content)
     if fd == 0:
@@ -152,6 +151,8 @@ def writefile(_endpoint, filepath, _userid, content, islock=False):
     # else for some reason we get a EBADF if we close a file opened with os.open, though it should be closed!
     if written != size:
       raise IOError('Written %d bytes but content is %d bytes' % (written, size))
+    log.info('msg="File written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' % \
+             (filepath, (tend-tstart)*1000, islock))
   except OSError as e:
     log.warning('msg="Error writing to file" filepath="%s" error="%s"' % (filepath, e))
     raise IOError(e)

--- a/src/localiface.py
+++ b/src/localiface.py
@@ -157,23 +157,6 @@ def writefile(_endpoint, filepath, _userid, content, islock=False):
     log.warning('msg="Error writing to file" filepath="%s" error="%s"' % (filepath, e))
     raise IOError(e)
 
-def openfileexcl(_endpoint, filepath, _userid, content):
-  if isinstance(content, str):
-    content = bytes(content, 'UTF-8')
-  size = len(content)
-  filepath = _getfilepath(filepath)
-  log.debug('msg="Invoking openfileexcl" filepath="%s" size="%d"' % (filepath, size))
-  tstart = time.time()
-  fd = 0
-  try:
-    fd = os.open(filepath, os.O_CREAT | os.O_EXCL)   # no O_BINARY in Linux
-    f = os.fdopen(fd, mode='wb')
-  except FileExistsError:
-    log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
-    raise IOError('File exists and islock flag requested')
-  tend = time.time()
-  log.info('msg="openfileexcl completed, file left open" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
-
 
 def renamefile(_endpoint, origfilepath, newfilepath, _userid):
   '''Rename a file from origfilepath to newfilepath on behalf of the given userid.'''

--- a/src/localiface.py
+++ b/src/localiface.py
@@ -135,7 +135,7 @@ def writefile(_endpoint, filepath, _userid, content, islock=False):
       fd = os.open(filepath, os.O_CREAT | os.O_EXCL)   # no O_BINARY in Linux
       f = os.fdopen(fd, mode='wb')
     except FileExistsError:
-      log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
+      log.info('msg="File exists on write but islock flag requested" filepath="%s"' % filepath)
       raise IOError('File exists and islock flag requested')
   else:
     try:

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -747,7 +747,7 @@ def wopiGetLock(fileid, _reqheaders_unused, acctok):
   # we might want to check if a non-WOPI lock exists for this file:
   #try:
   #  lockstat = storage.stat(acctok['endpoint'], utils.getLibreOfficeLockName(acctok['filename']), acctok['userid'])
-  #  return utils.makeConflictResponse('GetLock', 'Locked by Libre Office', '', '', acctok['filename'])
+  #  return utils.makeConflictResponse('GetLock', 'Locked by an external application', '', '', acctok['filename'])
   #except IOError:
   #  pass
   # however implications have to be properly understood as we've seen cases of locks left behind

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -228,7 +228,7 @@ def handleException(e):
 @Wopi.app.route("/wopi", methods=['GET'])
 def index():
   '''Return a default index page with some user-friendly information about this service'''
-  Wopi.log.info('msg="Accessed index page" client="%s"' % flask.request.remote_addr)
+  Wopi.log.debug('msg="Accessed index page" client="%s"' % flask.request.remote_addr)
   return """
     <html><head><title>ScienceMesh WOPI Server</title></head>
     <body>
@@ -552,7 +552,10 @@ def cboxUnlock():
     if 'OnlyOffice Online Editor' in lock:
       # remove the LibreOffice-compatible lock file
       storage.removefile(endpoint, utils.getLibreOfficeLockName(filename), userid, 1)
-      Wopi.log.info('msg="cboxUnlock: successfully removed LibreOffice-compatible lock file" filename="%s"' % filename)
+      # and log this along with the previous lockid for reference
+      lockid = int(lock.split(';\n')[1].strip(';'))
+      Wopi.log.info('msg="cboxUnlock: successfully removed LibreOffice-compatible lock file" filename="%s" id="%d"' % \
+                    (filename, lockid))
       return 'OK', http.client.OK
     # else another lock exists
     Wopi.log.info('msg="cboxUnlock: lock file held by another application" filename="%s" holder="%s"' % \

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -462,7 +462,7 @@ def cboxLock():
       # provided we can extend it in a similar way.
       lolockcontent = ',OnlyOffice Online Editor,%s,%s,ExtWebApp;\n%d;' % \
            (Wopi.wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())), lockid)
-      storage.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, 1)
+      storage.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, islock=True)
       Wopi.log.info('msg="cboxLock: (re)created LibreOffice-compatible lock file" filename="%s" id="%d"' % (filename, lockid))
       return str(lockid), http.client.OK
     if query and filestat['mtime'] > lockstat['mtime']:

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -587,10 +587,6 @@ def wopiCheckFileInfo(fileid):
     # populate metadata for this file
     filemd = {}
     filemd['BaseFileName'] = filemd['BreadcrumbDocName'] = os.path.basename(acctok['filename'])
-    if acctok['extlock']:
-      # an external lock was found: let's somehow tell the user that the file is forced readonly
-      # note that we strip the extension, otherwise Office would strip it (along with our comment!)
-      filemd['BreadcrumbDocName'] = os.path.splitext(filemd['BaseFileName'])[0] + ' (locked by another app)'
     furl = acctok['folderurl']
     # encode the path part as it is going to be an URL GET argument
     filemd['BreadcrumbFolderUrl'] = furl[:furl.find('=')+1] + urllib.parse.quote_plus(furl[furl.find('=')+1:])

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -181,13 +181,14 @@ def storeWopiLock(operation, lock, acctok):
   try:
     # store the lock as encoded JWT
     s = jwt.encode(lockcontent, _ctx['wopi'].wopisecret, algorithm='HS256')
-    _ctx['st'].writefile(acctok['endpoint'], getLockName(acctok['filename']), acctok['userid'], s, 1)
+    _ctx['st'].writefile(acctok['endpoint'], getLockName(acctok['filename']), acctok['userid'], s, islock=True)
     _ctx['log'].info('msg="%s" filename="%s" token="%s" lock="%s" result="success"' % \
                      (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock))
     # also create a LibreOffice-compatible lock file for interoperability purposes
     lockcontent = ',Collaborative Online Editor,%s,%s,WOPIServer;' % \
                   (_ctx['wopi'].wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())))
-    _ctx['st'].writefile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], lockcontent, 1)
+    _ctx['st'].writefile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], \
+                         lockcontent, islock=True)
   except IOError as e:
     _ctx['log'].warning('msg="%s" filename="%s" token="%s" lock="%s" result="unable to store lock" reason="%s"' % \
                         (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -151,8 +151,8 @@ def storeWopiLock(operation, lock, acctok):
   try:
     # first try to look for a MS Office lock
     lockInfo = _ctx['st'].stat(acctok['endpoint'], getMicrosoftOfficeLockName(acctok['filename']), acctok['userid'])
-    _ctx['log'].warning('msg="WOPI lock denied because of an existing Microsoft Office lock" filename="%s" mtime="%ld"' % \
-                        (acctok['filename'], lockInfo['mtime']))
+    _ctx['log'].info('msg="WOPI lock denied because of an existing Microsoft Office lock" filename="%s" mtime="%ld"' % \
+                     (acctok['filename'], lockInfo['mtime']))
     raise IOError('File exists and islock flag requested')
   except IOError as e:
     if 'File exists and islock flag requested' in str(e):
@@ -172,14 +172,14 @@ def storeWopiLock(operation, lock, acctok):
                                                getLibreOfficeLockName(acctok['filename']), acctok['userid'])).decode('utf-8')
       if 'WOPIServer' not in retrievedlock:
         # the file was externally locked, make this call fail
-        _ctx['log'].warning('msg="WOPI lock denied because of an existing LibreOffice lock" filename="%s" holder="%s"' % \
-                            (acctok['filename'], retrievedlock.split(',')[1] if ',' in retrievedlock else retrievedlock))
+        _ctx['log'].info('msg="WOPI lock denied because of an existing LibreOffice lock" filename="%s" holder="%s"' % \
+                         (acctok['filename'], retrievedlock.split(',')[1] if ',' in retrievedlock else retrievedlock))
         raise
       #else it's our previous lock: all right, move on
     else:
       # any other error is logged and raised
-      _ctx['log'].warning('msg="%s" filename="%s" token="%s" lock="%s" result="unable to store LibreOffice-compatible lock" reason="%s"' % \
-                          (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
+      _ctx['log'].error('msg="%s: unable to store LibreOffice-compatible lock" filename="%s" token="%s" lock="%s" reason="%s"' % \
+                        (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
       raise
   try:
     # now store the lock as encoded JWT: note that we do not use islock=True, because the WOPI specs require
@@ -195,8 +195,8 @@ def storeWopiLock(operation, lock, acctok):
                      (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock))
   except IOError as e:
     # any other error is logged and raised
-    _ctx['log'].warning('msg="%s" filename="%s" token="%s" lock="%s" result="unable to store WOPI lock" reason="%s"' % \
-                        (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
+    _ctx['log'].error('msg="%s: unable to store WOPI lock" filename="%s" token="%s" lock="%s" reason="%s"' % \
+                      (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
     raise
 
 

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -195,8 +195,8 @@ def storeWopiLock(operation, lock, acctok):
   except IOError as e:
     if 'File exists and islock flag requested' in str(e):
       # retrieve the LibreOffice-compatible lock just found
-      lock = next(_ctx['st'].readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid']))
-      if 'WOPIServer' not in lock:
+      retrievedlock = next(_ctx['st'].readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid']))
+      if 'WOPIServer' not in retrievedlock.decode('utf-8'):
         # the file was externally locked, make this call fail
         raise
       #else it's our previous lock: all right, nothing else to do

--- a/src/wopiutils.py
+++ b/src/wopiutils.py
@@ -229,13 +229,16 @@ def compareWopiLocks(lock1, lock2):
     return False
 
 
-def makeConflictResponse(operation, retrievedlock, lock, oldlock, filename):
+def makeConflictResponse(operation, retrievedlock, lock, oldlock, filename, reason=None):
   '''Generates and logs an HTTP 401 response in case of locks conflict'''
   resp = flask.Response()
   resp.headers['X-WOPI-Lock'] = retrievedlock if retrievedlock else ''
+  if reason:
+    resp.headers['X-WOPI-LockFailureReason'] = reason
   resp.status_code = http.client.CONFLICT
-  _ctx['log'].info('msg="%s" filename="%s" token="%s", lock="%s" oldLock="%s" retrievedLock="%s" result="conflict"' % \
-                   (operation.title(), filename, flask.request.args['access_token'][-20:], lock, oldlock, retrievedlock))
+  _ctx['log'].info('msg="%s" filename="%s" token="%s" lock="%s" oldLock="%s" retrievedLock="%s" %s' % \
+                   (operation.title(), filename, flask.request.args['access_token'][-20:], \
+                    lock, oldlock, retrievedlock, ('reason="%s"' % reason if reason else 'result="conflict"')))
   return resp
 
 

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -254,25 +254,6 @@ def writefile(endpoint, filepath, userid, content, islock=False):
            (filepath, (tend-tstart)*1000, islock))
 
 
-def openfileexcl(endpoint, filepath, userid, content):
-  size = len(content)
-  log.debug('msg="Invoking openfileexcl" filepath="%s" size="%d" userid="%s"' % (filepath, size, userid))
-  f = XrdClient.File()
-  tstart = time.time()
-  rc, statInfo_unused = f.open(_geturlfor(endpoint) + '/' + homepath + filepath + _eosargs(userid, 0, size) + \
-                               ('&sys.versioning=0'), OpenFlags.NEW)
-  tend = time.time()
-  if not rc.ok:
-    if 'File exists' in rc.message:
-      log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
-      raise IOError('File exists and islock flag requested')
-    log.warning('msg="Error opening the file for write" filepath="%s" error="%s"' % (filepath, rc.message.strip('\n')))
-    raise IOError(rc.message.strip('\n'))
-  # write the file. In a future implementation, we should find a way to only update the required chunks...
-  #rc, statInfo_unused = f.write(content, offset=0, size=size)
-  log.info('msg="openfileexcl completed, file left open" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
-
-
 def renamefile(endpoint, origfilepath, newfilepath, userid):
   '''Rename a file via a special open from origfilepath to newfilepath on behalf of the given userid.'''
   _xrootcmd(endpoint, 'file', 'rename', userid, 'mgm.path=' + _getfilepath(origfilepath, encodeamp=True) + \

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -218,19 +218,24 @@ def readfile(endpoint, filepath, userid):
         yield chunk
 
 
-def writefile(endpoint, filepath, userid, content, noversion=0):
+def writefile(endpoint, filepath, userid, content, noversion=0, nooverwrite=0):
   '''Write a file via xroot on behalf of the given userid. The entire content is written
      and any pre-existing file is deleted (or moved to the previous version if supported).
-     If noversion=1, the write explicitly disables versioning: this is useful for lock files.'''
+     If noversion=1, the write explicitly disables versioning: this is useful for lock files.
+     If nooverwrite=1, the file is opened with O_CREAT|O_EXCL, preventing race conditions.'''
   size = len(content)
   log.debug('msg="Invoking writeFile" filepath="%s" size="%d"' % (filepath, size))
   f = XrdClient.File()
   tstart = time.time()
   rc, statInfo_unused = f.open(_geturlfor(endpoint) + '/' + homepath + filepath + _eosargs(userid, 1, size) + \
-                               ('&sys.versioning=0' if noversion else ''), OpenFlags.DELETE)
+                               ('&sys.versioning=0' if noversion else ''), \
+                               OpenFlags.DELETE if not nooverwrite else OpenFlags.NEW)
   tend = time.time()
   log.info('msg="File open for write" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
   if not rc.ok:
+    if nooverwrite and rc.shellcode == 50:
+      log.info('msg="File exists on write and nooverwrite flag requested" filepath="%s"' % filepath)
+      raise IOError('File exists and nooverwrite flag requested')
     log.warning('msg="Error opening the file for write" filepath="%s" error="%s"' % (filepath, rc.message.strip('\n')))
     raise IOError(rc.message.strip('\n'))
   # write the file. In a future implementation, we should find a way to only update the required chunks...

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -127,7 +127,9 @@ def statx(endpoint, filepath, userid, versioninv=0):
   log.info('msg="Invoked stat" filepath="%s"' % _getfilepath(filepath))
   if '[SUCCESS]' not in str(rc):
     raise IOError(str(rc).strip('\n'))
-  if 'retc=' in info:
+  if 'retc=2\\x00' in info:
+    raise IOError('No such file or directory')   # convert ENOENT
+  elif 'retc=' in info:
     raise IOError(info.strip('\n'))
   statxdata = info.split()
   if versioninv == 0:

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -235,8 +235,10 @@ def writefile(endpoint, filepath, userid, content, islock=False):
   tend = time.time()
   if not rc.ok:
     if islock and 'File exists' in rc.message:
-      log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
+      # racing against an existing file
+      log.info('msg="File exists on write but islock flag requested" filepath="%s"' % filepath)
       raise IOError('File exists and islock flag requested')
+    # any other failure is reported as is
     log.warning('msg="Error opening the file for write" filepath="%s" error="%s"' % (filepath, rc.message.strip('\n')))
     raise IOError(rc.message.strip('\n'))
   # write the file. In a future implementation, we should find a way to only update the required chunks...

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -254,6 +254,25 @@ def writefile(endpoint, filepath, userid, content, islock=False):
            (filepath, (tend-tstart)*1000, islock))
 
 
+def openfileexcl(endpoint, filepath, userid, content):
+  size = len(content)
+  log.debug('msg="Invoking openfileexcl" filepath="%s" size="%d" userid="%s"' % (filepath, size, userid))
+  f = XrdClient.File()
+  tstart = time.time()
+  rc, statInfo_unused = f.open(_geturlfor(endpoint) + '/' + homepath + filepath + _eosargs(userid, 0, size) + \
+                               ('&sys.versioning=0'), OpenFlags.NEW)
+  tend = time.time()
+  if not rc.ok:
+    if 'File exists' in rc.message:
+      log.info('msg="File exists on write and islock flag requested" filepath="%s"' % filepath)
+      raise IOError('File exists and islock flag requested')
+    log.warning('msg="Error opening the file for write" filepath="%s" error="%s"' % (filepath, rc.message.strip('\n')))
+    raise IOError(rc.message.strip('\n'))
+  # write the file. In a future implementation, we should find a way to only update the required chunks...
+  #rc, statInfo_unused = f.write(content, offset=0, size=size)
+  log.info('msg="openfileexcl completed, file left open" filepath="%s" elapsedTimems="%.1f"' % (filepath, (tend-tstart)*1000))
+
+
 def renamefile(endpoint, origfilepath, newfilepath, userid):
   '''Rename a file via a special open from origfilepath to newfilepath on behalf of the given userid.'''
   _xrootcmd(endpoint, 'file', 'rename', userid, 'mgm.path=' + _getfilepath(origfilepath, encodeamp=True) + \

--- a/src/xrootiface.py
+++ b/src/xrootiface.py
@@ -53,8 +53,8 @@ def _eosargs(userid, atomicwrite=0, bookingsize=0):
       raise ValueError
     ruid = int(userid[0])
     rgid = int(userid[1])
-    return '?eos.ruid=' + str(ruid) + '&eos.rgid=' + str(rgid) + ('&eos.atomic=1' if atomicwrite else '') + \
-            (('&eos.bookingsize='+str(bookingsize)) if bookingsize else '') + '&eos.app=wopi'
+    return '?eos.ruid=%d&eos.rgid=%d' % (ruid, rgid) + '&eos.app=' + ('fuse::wopi' if not atomicwrite else 'wopi') + \
+            (('&eos.bookingsize='+str(bookingsize)) if bookingsize else '')
   except (ValueError, IndexError):
     raise ValueError('Only Unix-based userid is supported with xrootd storage')
 
@@ -229,8 +229,7 @@ def writefile(endpoint, filepath, userid, content, islock=False):
   log.debug('msg="Invoking writeFile" filepath="%s" userid="%s" size="%d" islock="%s"' % (filepath, userid, size, islock))
   f = XrdClient.File()
   tstart = time.time()
-  rc, statInfo_unused = f.open(_geturlfor(endpoint) + '/' + homepath + filepath + _eosargs(userid, not islock, size) + \
-                               ('&sys.versioning=0' if islock else ''), \
+  rc, statInfo_unused = f.open(_geturlfor(endpoint) + '/' + homepath + filepath + _eosargs(userid, not islock, size),
                                OpenFlags.NEW if islock else OpenFlags.DELETE)
   tend = time.time()
   if not rc.ok:

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -132,14 +132,14 @@ class TestStorage(unittest.TestCase):
     with self.assertRaises(IOError):
       self.storage.stat(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
 
-  def test_write_nooverwrite(self):
-    '''Test double write with nooverwrite flag'''
+  def test_write_islock(self):
+    '''Test double write with islock flag'''
     buf = b'ebe5tresbsrdthbrdhvdtr'
-    self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, nooverwrite=1)
+    self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, islock=True)
     statInfo = self.storage.stat(self.endpoint, '/testoverwrite', self.userid)
     self.assertIsInstance(statInfo, dict)
     with self.assertRaises(IOError):
-      self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, nooverwrite=1)
+      self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, islock=True)
     self.storage.removefile(self.endpoint, '/testoverwrite', self.userid)
 
   def test_remove_nofile(self):

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -122,7 +122,7 @@ class TestStorage(unittest.TestCase):
     self.assertIsInstance(readex, IOError, 'readfile returned %s' % readex)
     self.assertEqual(str(readex), 'No such file or directory', 'readfile returned %s' % readex)
 
-  def test_write_remove(self):
+  def test_write_remove_specialchars(self):
     '''Test write and removal of a file with special chars'''
     buf = b'ebe5tresbsrdthbrdhvdtr'
     self.storage.writefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid, buf)
@@ -131,6 +131,16 @@ class TestStorage(unittest.TestCase):
     self.storage.removefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
     with self.assertRaises(IOError):
       self.storage.stat(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
+
+  def test_write_nooverwrite(self):
+    '''Test double write with nooverwrite flag'''
+    buf = b'ebe5tresbsrdthbrdhvdtr'
+    self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, nooverwrite=1)
+    statInfo = self.storage.stat(self.endpoint, '/testoverwrite', self.userid)
+    self.assertIsInstance(statInfo, dict)
+    with self.assertRaises(IOError):
+      self.storage.writefile(self.endpoint, '/testoverwrite', self.userid, buf, nooverwrite=1)
+    self.storage.removefile(self.endpoint, '/testoverwrite', self.userid)
 
   def test_remove_nofile(self):
     '''Test removal of a non-existing file'''

--- a/test/wopiserver-test.conf
+++ b/test/wopiserver-test.conf
@@ -23,8 +23,8 @@ endpoint = 123e4567-e89b-12d3-a456-426655440000
 storagehomepath = /home
 
 [xroot]
-storageserver = root://eosuser
+storageserver = root://eoshome-i00
 userid = 0:0
-endpoint = root://eoshome-l
+endpoint = root://eoshome-i00
 storagehomepath = /eos/dev/test/instancetest
 


### PR DESCRIPTION
This is to better support lock operations in the `/wopi/cbox/lock` and `/wopi/cbox/unlock` WOPI extensions.

Work to do:
- [x] Pass the unit test suite
- [x] Modify the `cboxLock()` call to make use of this call as opposed to `stat` and `write`, which is not atomic and prone to race conditions.
- [ ] Test the race with multiple OnlyOffice sessions
- [x] Validate WOPI Lock