### PR TITLE
'custom_dns' in docker build steps to workaround dind DNS issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,9 @@ steps:
       from_secret: dockerhub_password
     build_args:
       - VERSION=${DRONE_SEMVER_SHORT}-g${DRONE_COMMIT:0:7}
+    custom_dns:
+      - 128.142.17.5
+      - 128.142.16.5
 
 ---
 kind: pipeline
@@ -60,6 +63,9 @@ steps:
       from_secret: dockerhub_password
     build_args:
       - VERSION=${DRONE_TAG}
+    custom_dns:
+      - 128.142.17.5
+      - 128.142.16.5
 
 ---
 kind: pipeline
@@ -89,3 +95,6 @@ steps:
       from_secret: dockerhub_password
     build_args:
       - VERSION=${DRONE_TAG}
+    custom_dns:
+      - 128.142.17.5
+      - 128.142.16.5


### PR DESCRIPTION
Note: this disables cloud.drone.io from building the images, as the alternative DNS servers are internal-only.