### PR TITLE
Adapt to new CS3API Reference

### DIFF
--- a/src/cs3iface.py
+++ b/src/cs3iface.py
@@ -69,7 +69,7 @@ def stat(endpoint, fileid, userid, versioninv=0):
     ref = cs3spr.Reference(path=fileid)
   else:
     # assume we have an opaque fileid
-    ref = cs3spr.Reference(id=cs3spr.ResourceId(storage_id=endpoint, opaque_id=fileid))
+    ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, opaque_id=fileid))
   statInfo = ctx['cs3stub'].Stat(request=cs3sp.StatRequest(ref=ref),
                                  metadata=[('x-access-token', userid)])
   tend = time.time()


### PR DESCRIPTION
With latest master of the WOPI server I get following error. My fix only works with latest REVA. Changes were introduced in https://github.com/cs3org/cs3apis/pull/130

```
wopiserver_1       | {"time": "2021-06-23T08:46:25", "host": "8463d56ab59d", "process": "WOPIServer", "level": "ERROR", msg="Unexpected exception caught" exception="Protocol message Reference has no "id" field." type="<class 'ValueError'>" traceback="['Traceback (most recent call last):\n', '  File "/usr/local/lib/python3.8/site-packages/prometheus_flask_exporter/__init__.py", line 639, in func\n    response = f(*args, **kwargs)\n', '  File "/app/wopiserver.py", line 309, in iopOpen\n    inode, acctok = utils.generateAccessToken(userid, fileid, viewmode, username, folderurl, endpoint)\n', '  File "/app/wopiutils.py", line 118, in generateAccessToken\n    statInfo = st.statx(endpoint, fileid, userid, versioninv=1)\n', '  File "/app/cs3iface.py", line 99, in statx\n    return stat(endpoint, fileid, userid, versioninv)\n', '  File "/app/cs3iface.py", line 72, in stat\n    ref = cs3spr.Reference(id=cs3spr.ResourceId(storage_id=endpoint, opaque_id=fileid))\n', 'ValueError: Protocol message Reference has no "id" field.\n']" client="172.17.4.4" requestedUrl="http://wopiserver.owncloud.test/wopi/iop/open?endpoint=1284d238-aa92-42ce-bdc4-0b0000009157&filename=1486fd00-9139-4aea-afc8-e9baa2711eeb&folderurl=%2Fusers%2F4c510ada-c86b-4815-8820-42cdf82c3d51&username=Albert+Einstein&viewmode=VIEW_MODE_READ_WRITE" token="N/A"}
```