### PR TITLE
Limit conflict files to one per hour

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -438,7 +438,7 @@ def putFile(fileid):
             # either the file was deleted or it was updated/overwritten by others: force conflict
             newname, ext = os.path.splitext(acctok['filename'])
             # !!! typical EFSS formats are like '<filename>_conflict-<date>-<time>', but they're not synchronized back !!!
-            newname = '%s-conflict-%s%s' % (newname, time.strftime('%Y%m%d-%H%M%S'), ext.strip())
+            newname = '%s-webconflict-%s%s' % (newname, time.strftime('%Y%m%d-%H'), ext.strip())
             utils.storeWopiFile(flask.request, acctok, utils.LASTSAVETIMEKEY, newname)
             # keep track of this action in the original file's xattr, to avoid looping (see below)
             st.setxattr(acctok['endpoint'], acctok['filename'], acctok['userid'], utils.LASTSAVETIMEKEY, 0)


### PR DESCRIPTION
This mini PR changes the filename pattern used to generate conflict files, in the case when a file is requested to be overwritten (via WOPI PutFile) but it had changed in the storage via other requests (e.g. sync client).

The motivation is to limit the proliferation of such conflict files: the user may not immediately realize a conflict was generated (often because the save operations happen asynchronously) and keeps using the application, therefore ending up with several conflict files where only the last one is relevant.

The new pattern uses just the hour as opposed to hour-minute-second.