### PR TITLE
New feature: implement locking via Lock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ This service is part of the ScienceMesh Interoperability Platform (IOP) and impl
 It enables ScienceMesh EFSS storages to integrate Office Online platforms including Microsoft Office Online and Collabora Online. In addition it implements a [bridge](src/bridge/readme.md) module with dedicated extensions to support apps like CodiMD and Etherpad.
 
 Author: Giuseppe Lo Presti (@glpatcern) <br/>
-Contributions: Michael DSilva (@madsi1m), Lovisa Lugnegaard (@LovisaLugnegard), Samuel Alfageme (@SamuAlfageme), Ishank Arora (@ishank011), Willy Kloucek (@wkloucek)
+Contributors:
+- Michael DSilva (@madsi1m)
+- Lovisa Lugnegaard (@LovisaLugnegard)
+- Samuel Alfageme (@SamuAlfageme)
+- Ishank Arora (@ishank011)
+- Willy Kloucek (@wkloucek)
+- Gianmaria Del Monte (@gmgigi96)
+- Klaas Freitag (@dragotin)
 
 Initial revision: December 2016 <br/>
 First production version for CERNBox: September 2017 (presented at [oCCon17](https://occon17.owncloud.org) - [slides](https://www.slideshare.net/giuseppelopresti/collaborative-editing-and-more-in-cernbox))<br/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ requests
 more_itertools
 tuspy
 prometheus-flask-exporter
-cs3apis>=0.1.dev84
+cs3apis>=0.1.dev87
 waitress

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ requests
 more_itertools
 tuspy
 prometheus-flask-exporter
-cs3apis>=0.1.dev66
+cs3apis>=0.1.dev84
 waitress

--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -1,7 +1,7 @@
 '''
-The WOPI Bridge for IOP. This connector service supports CodiMD and Etherpad.
+The WOPI bridge extension for IOP. This connector service supports CodiMD and Etherpad.
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import os

--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -369,7 +369,10 @@ class SaveThread(threading.Thread):
                     del WB.openfiles[wopisrc]
             elif openfile['toclose'] != wopilock['toclose']:
                 # some user still on it, refresh lock if the toclose part has changed
-                wopic.refreshlock(wopisrc, openfile['acctok'], wopilock, toclose=openfile['toclose'])
+                try:
+                    wopic.refreshlock(wopisrc, openfile['acctok'], wopilock, toclose=openfile['toclose'])
+                except wopic.InvalidLock:
+                    WB.log.warning('msg="SaveThread: failed to refresh lock, will try again later" url="%s"' % wopisrc)
 
 
 @atexit.register

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -3,7 +3,7 @@ codimd.py
 
 The CodiMD-specific code used by the WOPI bridge.
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import os

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -233,13 +233,16 @@ def _getattachments(mddoc, docfilename, forcezip=False):
     return zip_buffer.getvalue(), response
 
 
-def savetostorage(wopisrc, acctok, isclose, wopilock):
+def savetostorage(wopisrc, acctok, isclose, wopilock, onlyfetch=False):
     '''Copy document from CodiMD back to storage'''
     # get document from CodiMD
     try:
         log.info('msg="Fetching file from CodiMD" isclose="%s" appurl="%s" token="%s"' %
                  (isclose, appurl + wopilock['docid'], acctok[-20:]))
         mddoc = _fetchfromcodimd(wopilock, acctok)
+        if onlyfetch:
+            # this is used only in case of recovery to local storage
+            return mddoc, http.client.OK
     except AppFailure:
         return wopic.jsonify('Could not save file, failed to fetch document from CodiMD'), http.client.INTERNAL_SERVER_ERROR
 

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -3,7 +3,7 @@ etherpad.py
 
 The Etherpad-specific code used by the WOPI bridge.
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 from random import choice

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -158,7 +158,10 @@ def savetostorage(wopisrc, acctok, isclose, wopilock):
     reply = wopic.handleputfile('PutFile', wopisrc, res)
     if reply:
         return reply
-    wopilock = wopic.refreshlock(wopisrc, acctok, wopilock, digest='dirty')
-    log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
-             (wopilock['filename'], isclose, acctok[-20:]))
-    return wopic.jsonify('File saved successfully'), http.client.OK
+    try:
+        wopilock = wopic.refreshlock(wopisrc, acctok, wopilock, digest='dirty')
+        log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
+                (wopilock['filename'], isclose, acctok[-20:]))
+        return wopic.jsonify('File saved successfully'), http.client.OK
+    except wopic.InvalidLock:
+        return wopic.jsonify('File saved, but failed to refresh lock'), http.client.INTERNAL_SERVER_ERROR

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -134,13 +134,16 @@ def _fetchfrometherpad(wopilock, acctok):
         raise AppFailure
 
 
-def savetostorage(wopisrc, acctok, isclose, wopilock):
+def savetostorage(wopisrc, acctok, isclose, wopilock, onlyfetch=False):
     '''Copy document from Etherpad back to storage'''
     # get document from Etherpad
     try:
         log.info('msg="Fetching file from Etherpad" isclose="%s" appurl="%s" token="%s"' %
                  (isclose, appurl + '/p' + wopilock['docid'], acctok[-20:]))
         epfile = _fetchfrometherpad(wopilock, acctok)
+        if onlyfetch:
+            # this is used only in case of recovery to local storage
+            return epfile, http.client.OK
     except AppFailure:
         return wopic.jsonify('Could not save file, failed to fetch document from Etherpad'), http.client.INTERNAL_SERVER_ERROR
 

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -154,8 +154,8 @@ def handleputfile(wopicall, wopisrc, res):
         return jsonify('Error saving the file. %s' % res.headers.get('X-WOPI-LockFailureReason')), \
                http.client.INTERNAL_SERVER_ERROR
     if res.status_code != http.client.OK:
+        # hopefully the server has kept a local copy for later recovery
         log.error('msg="Calling WOPI %s failed" url="%s" response="%s"' % (wopicall, wopisrc, res.status_code))
-        # TODO need to save the file on a local storage for later recovery
         return jsonify('Error saving the file, please contact support'), http.client.INTERNAL_SERVER_ERROR
     return None
 

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -1,9 +1,9 @@
 '''
 wopiclient.py
 
-A set of WOPI functions for the WOPI bridge service.
+A set of WOPI client functions for the WOPI bridge service.
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import os

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -113,7 +113,7 @@ def refreshlock(wopisrc, acctok, wopilock, digest=None, toclose=None):
         # else fail
     log.error('msg="Calling WOPI RefreshLock failed" url="%s" response="%d" reason="%s"' %
               (wopisrc, res.status_code, res.headers.get('X-WOPI-LockFailureReason')))
-    return None
+    raise InvalidLock('Failed to refresh the lock')
 
 
 def relock(wopisrc, acctok, docid, isclose):

--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -4,7 +4,7 @@ commoniface.py
 Common entities used by all storage interfaces for the IOP WOPI server.
 Includes functions to store and retrieve Reva-compatible locks.
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -63,7 +63,7 @@ def retrieverevalock(rawlock):
     if 'h' in l:
         # temporary code to support the data structure from WOPI 8.0
         l['app_name'] = l['h']
-        l['lock_id'] = l['md']
+        l['lock_id'] = 'opaquelocktoken:' + l['md']
         l['expiration'] = {}
         l['expiration']['seconds'] = l['exp']
     return l

--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -22,7 +22,7 @@ EXCL_ERROR = 'File exists and islock flag requested'
 ACCESS_ERROR = 'Operation not permitted'
 
 # name of the xattr storing the Reva lock
-LOCKKEY = 'user.iop.lock'
+LOCKKEY = 'iop.lock'
 
 # reference to global config
 config = None

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -218,7 +218,7 @@ def readfile(_endpoint, filepath, userid):
         yield IOError(common.ENOENT_MSG)
     elif initfiledownloadres.status.code != cs3code.CODE_OK:
         log.error('msg="Failed to initiateFileDownload on read" filepath="%s" reason="%s"' %
-                         (filepath, initfiledownloadres.status.message.replace('"', "'")))
+                  (filepath, initfiledownloadres.status.message.replace('"', "'")))
         yield IOError(initfiledownloadres.status.message)
     log.debug('msg="readfile: InitiateFileDownloadRes returned" protocols="%s"' % initfiledownloadres.protocols)
 
@@ -298,7 +298,7 @@ def renamefile(_endpoint, filepath, newfilepath, userid):
     log.debug('msg="Invoked renamefile" result="%s"' % res)
 
 
-def removefile(_endpoint, filepath, userid, force=False):
+def removefile(_endpoint, filepath, userid, _force=False):
     '''Remove a file using the given userid as access token.
        The force argument is ignored for now for CS3 storage.'''
     reference = cs3spr.Reference(path=filepath)

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -3,9 +3,7 @@ cs3iface.py
 
 CS3 API based interface for the IOP WOPI server
 
-Authors:
-Giuseppe.LoPresti@cern.ch, CERN/IT-ST
-Lovisa.Lugnegaard@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -298,6 +298,9 @@ def writefile(_endpoint, filepath, userid, content, lockid, islock=False):
         log.error('msg="Exception when uploading file to Reva" reason="%s"' % e)
         raise IOError(e)
     tend = time.time()
+    if putres.status_code == http.client.UNAUTHORIZED:
+        log.warning('msg="Access denied uploading file to Reva" reason="%s"' % putres.reason)
+        raise IOError(common.ACCESS_ERROR)
     if putres.status_code != http.client.OK:
         log.error('msg="Error uploading file to Reva" code="%d" reason="%s"' % (putres.status_code, putres.reason))
         raise IOError(putres.reason)

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -150,22 +150,49 @@ def rmxattr(_endpoint, filepath, userid, key):
 
 def setlock(endpoint, filepath, userid, appname, value):
     '''Set a lock to filepath with the given value metadata and appname as holder'''
-    raise NotImplementedError
+    reference = cs3spr.Reference(path=filepath)
+    lock = cs3spr.Lock(type=cs3spr.LOCK_TYPE_SHARED, holder=appname, metadata=value)
+    req = cs3sp.SetLockRequest(ref=reference, lock=lock)
+    res = ctx['cs3stub'].SetLock(request=req, metadata=[('x-access-token', userid)])
+    if res.status.code != cs3code.CODE_OK:
+        ctx['log'].error('msg="Failed to set lock" filepath="%s" appname="%s" value="%s" reason="%s"' % (filepath, appname, value, res.status.message.replace('"', "'")))
+        raise IOError(res.status.message)
+    ctx['log'].debug('msg="Invoked set lock" result="%s"' % res)
 
 
 def getlock(endpoint, filepath, userid, appname):
     '''Get the lock metadata for the given filepath'''
-    raise NotImplementedError
+    reference = cs3spr.Reference(path=filepath)
+    req = cs3sp.GetLockRequest(ref=reference)
+    res = ctx['cs3stub'].GetLock(request=req, metadata=[('x-access-token', userid)])
+    if res.status.code != cs3code.CODE_OK:
+        ctx['log'].error('msg="Failed to get lock" filepath="%s" reason="%s"' % (filepath, res.status.message.replace('"', "'")))
+        raise IOError(res.status.message)
+    ctx['log'].debug('msg="Invoked get lock" result="%s"' % res)
+    return res.lock
 
 
 def refreshlock(endpoint, filepath, userid, appname, value):
     '''Refresh the lock metadata for the given filepath'''
-    raise NotImplementedError
+    reference = cs3spr.Reference(path=filepath)
+    lock = cs3spr.Lock(type=cs3spr.LOCK_TYPE_SHARED, holder=appname, metadata=value)
+    req = cs3sp.RefreshLockRequest(ref=reference, lock=lock)
+    res = ctx['cs3stub'].RefreshLock(request=req, metadata=[('x-access-token', userid)])
+    if res.status.code != cs3code.CODE_OK:
+        ctx['log'].error('msg="Failed to refresh lock" filepath="%s" appname="%s" value="%s" reason="%s"' % (filepath, appname, value, res.status.message.replace('"', "'")))
+        raise IOError(res.status.message)
+    ctx['log'].debug('msg="Invoked refresh lock" result="%s"' % res)
 
 
 def unlock(endpoint, filepath, userid, appname):
     '''Remove the lock for the given filepath'''
-    raise NotImplementedError
+    reference = cs3spr.Reference(path=filepath)
+    req = cs3sp.UnlockRequest(ref=reference)
+    res = ctx['cs3stub'].Unlock(request=req, metadata=[('x-access-token', userid)])
+    if res.status.code != cs3code.CODE_OK:
+        ctx['log'].error('msg="Failed to unlock" filepath="%s" reason="%s"' % (filepath, res.status.message.replace('"', "'")))
+        raise IOError(res.status.message)
+    ctx['log'].debug('msg="Invoked unlock" result="%s"' % res)
 
 
 def readfile(_endpoint, filepath, userid):

--- a/src/core/discovery.py
+++ b/src/core/discovery.py
@@ -1,9 +1,12 @@
 '''
 discovery.py
 
-Helper code for the WOPI discovery phase, as well as
-for integrating the apps supported by the bridge functionality.
-This code is going to be deprecated once the new Reva AppProvider is fully functional.
+Helper code for the WOPI discovery phase, as well as for integrating the apps
+supported by the bridge functionality.
+This code is deprecated and is only used in conjunction with the xroot storage interface:
+when the WOPI server is interfaced to Reva via the cs3 storage interface this code is disabled.
+
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 from xml.etree import ElementTree as ET

--- a/src/core/ioplocks.py
+++ b/src/core/ioplocks.py
@@ -129,7 +129,7 @@ def createLock(filestat, filename, userid, endpoint):
                         (srv.wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())), lockid)
         # try to write in exclusive mode (and if a valid WOPI lock exists, assume the corresponding LibreOffice lock
         # is still there so the write will fail)
-        st.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, islock=True)
+        st.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, None, islock=True)
         log.info('msg="cboxLock: created LibreOffice-compatible lock file" filename="%s" fileid="%s" lockid="%ld"' %
                  (filename, filestat['inode'], lockid))
         return str(lockid), http.client.OK
@@ -179,7 +179,7 @@ def createLock(filestat, filename, userid, endpoint):
                 lockid = int(time.time())
             lolockcontent = ',OnlyOffice Online Editor,%s,%s,ExtWebApp;\n%d;' % \
                             (srv.wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())), lockid)
-            st.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, islock=False)
+            st.writefile(endpoint, utils.getLibreOfficeLockName(filename), userid, lolockcontent, None, islock=False)
             log.info('msg="cboxLock: refreshed LibreOffice-compatible lock file" filename="%s" fileid="%s" mtime="%ld" lockid="%ld"' %
                      (filename, filestat['inode'], filestat['mtime'], lockid))
             return str(lockid), http.client.OK
@@ -206,7 +206,7 @@ def iopunlock(filename, userid, endpoint):
         lock = lock.decode('UTF-8')
         if 'OnlyOffice Online Editor' in lock:
             # remove the LibreOffice-compatible lock file
-            st.removefile(endpoint, utils.getLibreOfficeLockName(filename), userid, 1)
+            st.removefile(endpoint, utils.getLibreOfficeLockName(filename), userid, True)
             # and log this along with the previous lockid for reference
             lockid = int(lock.split(';\n')[1].strip(';'))
             log.info('msg="cboxUnlock: successfully removed LibreOffice-compatible lock file" filename="%s" lockid="%ld"' %

--- a/src/core/ioplocks.py
+++ b/src/core/ioplocks.py
@@ -2,6 +2,8 @@
 ioplocks.py
 
 Implementation of the interoperable (iop) locking used for OnlyOffice and Office Desktop applications.
+
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -3,7 +3,7 @@ localiface.py
 
 Local storage interface for the IOP WOPI server
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -12,8 +12,6 @@ import warnings
 from stat import S_ISDIR
 import core.commoniface as common
 
-LOCKKEY = 'user.iop.lock'    # this is to be compatible with the (future) Lock API in Reva
-
 # module-wide state
 config = None
 log = None

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -10,7 +10,6 @@ import time
 import os
 import warnings
 from stat import S_ISDIR
-import json
 import core.commoniface as common
 
 LOCKKEY = 'user.iop.lock'    # this is to be compatible with the (future) Lock API in Reva
@@ -81,7 +80,7 @@ def setxattr(_endpoint, filepath, _userid, key, value):
     '''Set the extended attribute <key> to <value> on behalf of the given userid'''
     try:
         os.setxattr(_getfilepath(filepath), 'user.' + key, str(value).encode())
-    except (FileNotFoundError, PermissionError, OSError) as e:
+    except OSError as e:
         log.error('msg="Failed to setxattr" filepath="%s" key="%s" exception="%s"' % (filepath, key, e))
         raise IOError(e)
 
@@ -91,7 +90,7 @@ def getxattr(_endpoint, filepath, _userid, key):
     try:
         filepath = _getfilepath(filepath)
         return os.getxattr(filepath, 'user.' + key).decode('UTF-8')
-    except (FileNotFoundError, PermissionError, OSError) as e:
+    except OSError as e:
         log.error('msg="Failed to getxattr" filepath="%s" key="%s" exception="%s"' % (filepath, key, e))
         return None
 
@@ -100,7 +99,7 @@ def rmxattr(_endpoint, filepath, _userid, key):
     '''Remove the extended attribute <key> on behalf of the given userid'''
     try:
         os.removexattr(_getfilepath(filepath), 'user.' + key)
-    except (FileNotFoundError, PermissionError, OSError) as e:
+    except OSError as e:
         log.error('msg="Failed to rmxattr" filepath="%s" key="%s" exception="%s"' % (filepath, key, e))
         raise IOError(e)
 
@@ -118,7 +117,7 @@ def getlock(endpoint, filepath, _userid):
     '''Get the lock metadata as an xattr on behalf of the given userid'''
     l = getxattr(endpoint, filepath, '0:0', common.LOCKKEY)
     if l:
-        return json.loads(l)
+        return common.retrieverevalock(l)
     return None
 
 def refreshlock(endpoint, filepath, _userid, appname, value):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -13,6 +13,8 @@ from stat import S_ISDIR
 import json
 import core.commoniface as common
 
+LOCKKEY = 'user.iop.lock'    # this is to be compatible with the (future) Lock API in Reva
+
 # module-wide state
 config = None
 log = None

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -124,9 +124,14 @@ def refreshlock(endpoint, filepath, _userid, appname, value):
     log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     l = getlock(endpoint, filepath, _userid)
     if not l:
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is not locked'))
         raise IOError('File was not locked')
     if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
         raise IOError('File is locked by %s' % l['app_name'])
+    log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     # this is non-atomic, but the lock was already held
     setxattr(endpoint, filepath, '0:0', common.LOCKKEY, common.genrevalock(appname, value), None)
 
@@ -137,7 +142,7 @@ def unlock(endpoint, filepath, _userid, _appname, value):
     rmxattr(endpoint, filepath, '0:0', common.LOCKKEY, None)
 
 
-def readfile(_endpoint, filepath, _userid):
+def readfile(_endpoint, filepath, _userid, _lockid):
     '''Read a file on behalf of the given userid. Note that the function is a generator, managed by Flask.'''
     log.debug('msg="Invoking readFile" filepath="%s"' % filepath)
     try:

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -211,7 +211,7 @@ def unlock(fileid, reqheaders, acctok):
         return utils.makeConflictResponse('UNLOCK', retrievedLock, lock, '', acctok['filename'])
     # OK, the lock matches. Remove any extended attribute related to locks and conflicts handling
     try:
-        st.unlock(acctok['endpoint'], acctok['filename'], acctok['userid'], acctok['appname'])
+        st.unlock(acctok['endpoint'], acctok['filename'], acctok['userid'], acctok['appname'], utils.encodeLock(lock))
     except IOError:
         # ignore, it's not worth to report anything here
         pass

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -420,9 +420,9 @@ def putFile(fileid):
             try:
                 utils.storeWopiFile(flask.request, retrievedLock, acctok, utils.LASTSAVETIMEKEY, newname)
             except IOError as e:
-                if common.ACCESS_ERROR in str(e):
+                if common.ACCESS_ERROR in str(e) and srv.conflictpath:
                     # let's try the user's home instead of the current folder
-                    newname = utils.getuserhome(acctok['username']) + os.path.sep + os.path.basename(newname)
+                    newname = utils.getconflictpath(acctok['username']) + os.path.sep + os.path.basename(newname)
                     utils.storeWopiFile(flask.request, retrievedLock, acctok, utils.LASTSAVETIMEKEY, newname)
 
             # keep track of this action in the original file's xattr, to avoid looping (see below)

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -257,7 +257,7 @@ def putRelative(fileid, reqheaders, acctok):
                 log.warning('msg="PutRelative" user="%s" filename="%s" token="%s" suggTarget="%s" error="%s"' %
                             (acctok['userid'][-20:], targetName, flask.request.args['access_token'][-20:], \
                              suggTarget, str(e)))
-                return 'Illegal filename %s' % targetName, http.client.BAD_REQUEST
+                return 'Illegal filename', http.client.BAD_REQUEST
     else:
         # the relative target is a filename to be respected, and that may overwrite an existing file
         relTarget = os.path.dirname(acctok['filename']) + os.path.sep + relTarget    # make full path
@@ -276,7 +276,7 @@ def putRelative(fileid, reqheaders, acctok):
     try:
         utils.storeWopiFile(flask.request, None, acctok, utils.LASTSAVETIMEKEY, targetName)
     except IOError as e:
-        utils.storeForRecovery(flask.request.get_data(), targetName, flask.request.args['access_token'][-20:], e)
+        utils.storeForRecovery(flask.request.get_data(), targetName, flask.request.args['access_token'][-20:], e)  # lgtm [py/path-injection]
         return IO_ERROR, http.client.INTERNAL_SERVER_ERROR
     # generate an access token for the new file
     log.info('msg="PutRelative: generating new access token" user="%s" filename="%s" ' \

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -114,7 +114,9 @@ def getFile(fileid):
         log.info('msg="GetFile" user="%s" filename="%s" fileid="%s" token="%s"' %
                  (acctok['userid'][-20:], acctok['filename'], fileid, flask.request.args['access_token'][-20:]))
         # get the file reader generator
-        f = peekable(st.readfile(acctok['endpoint'], acctok['filename'], acctok['userid']))
+        # TODO for the time being we do not look if the file is locked. Once exclusive locks are implemented in Reva,
+        # the lock must be fetched prior to the following call in order to access the file.
+        f = peekable(st.readfile(acctok['endpoint'], acctok['filename'], acctok['userid'], None))
         firstchunk = f.peek()
         if isinstance(firstchunk, IOError):
             return ('Failed to fetch file from storage: %s' % firstchunk), http.client.INTERNAL_SERVER_ERROR

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -3,6 +3,8 @@
 srv.py
 
 Implementation of the core WOPI API
+
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -88,7 +88,7 @@ def checkFileInfo(fileid):
 
         res = flask.Response(json.dumps(fmd), mimetype='application/json')
         # amend sensitive metadata for the logs
-        fmd['HostViewUrl'] = fmd['HostEditUrl'] = fmd['DownloadUrl'] = '_amended_'
+        fmd['HostViewUrl'] = fmd['HostEditUrl'] = fmd['DownloadUrl'] = '_redacted_'
         log.info('msg="File metadata response" token="%s" metadata="%s"' % (flask.request.args['access_token'][-20:], fmd))
         return res
     except IOError as e:

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -81,7 +81,8 @@ def logGeneralExceptionAndReturn(ex, req):
     '''Convenience function to log a stack trace and return HTTP 500'''
     ex_type, ex_value, ex_traceback = sys.exc_info()
     log.critical('msg="Unexpected exception caught" exception="%s" type="%s" traceback="%s" client="%s" requestedUrl="%s"' %
-                 (ex, ex_type, traceback.format_exception(ex_type, ex_value, ex_traceback), req.remote_addr, req.url))
+                 (ex, ex_type, traceback.format_exception(ex_type, ex_value, ex_traceback), req.remote_addr, \
+                  req.url[0:req.url.find('?')] + '?_args_redacted_' if req.url.find('?') > 0 else req.url))
     return 'Internal error, please contact support', http.client.INTERNAL_SERVER_ERROR
 
 

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -1,7 +1,9 @@
 '''
 wopiutils.py
 
-General Low-level functions to support the WOPI server
+General low-level functions to support the WOPI server.
+
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import sys

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -170,7 +170,7 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefilename=Non
             raise IOError
     except IOError as e:
         log.info('msg="%s" user="%s" filename="%s" token="%s" error="No lock found"' %
-                (operation.title(), acctok['userid'][-20:], acctok['filename'], encacctok))
+                 (operation.title(), acctok['userid'][-20:], acctok['filename'], encacctok))
         return None, None
 
     try:
@@ -194,7 +194,7 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefilename=Non
             pass
         # also remove the LibreOffice-compatible lock file, if it exists and has the expected signature - cf. storeWopiLock()
         try:
-            lolock = next(st.readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid']))
+            lolock = next(st.readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], None))
             if isinstance(lolock, IOError):
                 raise lolock
             if 'WOPIServer' in lolock.decode('UTF-8'):
@@ -261,7 +261,7 @@ def storeWopiLock(fileid, operation, lock, oldlock, acctok, isoffice):
                 # retrieve the LibreOffice-compatible lock just found
                 try:
                     retrievedlolock = next(st.readfile(acctok['endpoint'], \
-                                           getLibreOfficeLockName(acctok['filename']), acctok['userid']))
+                                           getLibreOfficeLockName(acctok['filename']), acctok['userid'], None))
                     if isinstance(retrievedlolock, IOError):
                         raise retrievedlolock
                     retrievedlolock = retrievedlolock.decode('UTF-8')
@@ -296,7 +296,7 @@ def storeWopiLock(fileid, operation, lock, oldlock, acctok, isoffice):
                             (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], e))
 
     try:
-        # now atomically store the lock as encoded JWT
+        # now atomically store the lock
         st.setlock(acctok['endpoint'], acctok['filename'], acctok['userid'], acctok['appname'], encodeLock(lock))
         log.info('msg="%s" filename="%s" token="%s" lock="%s" result="success"' %
                  (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock))

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -171,7 +171,7 @@ def retrieveWopiLock(fileid, operation, lock, acctok, overridefilename=None):
     try:
         # check validity: a lock is deemed expired if the most recent between its expiration time and the last
         # save time by WOPI has passed
-        retrievedLock = jwt.decode(lockcontent['md'], srv.wopisecret, algorithms=['HS256'])
+        retrievedLock = jwt.decode(lockcontent['lock_id'], srv.wopisecret, algorithms=['HS256'])
         savetime = st.getxattr(acctok['endpoint'], acctok['filename'], acctok['userid'], LASTSAVETIMEKEY)
         if max(0 if 'exp' not in retrievedLock else retrievedLock['exp'],
                0 if not savetime else int(savetime) + srv.config.getint('general', 'wopilockexpiration')) < time.time():
@@ -201,7 +201,7 @@ def retrieveWopiLock(fileid, operation, lock, acctok, overridefilename=None):
     log.info('msg="%s" user="%s" filename="%s" fileid="%s" lock="%s" retrievedlock="%s" expTime="%s" token="%s"' %
              (operation.title(), acctok['userid'][-20:], acctok['filename'], fileid, lock, retrievedLock['wopilock'],
               time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime(retrievedLock['exp'])), encacctok))
-    return retrievedLock['wopilock'], lockcontent['h']
+    return retrievedLock['wopilock'], lockcontent['app_name']
 
 
 def _makeLock(lock):

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -159,7 +159,8 @@ def generateAccessToken(userid, fileid, viewmode, user, folderurl, endpoint, app
 
 
 def retrieveWopiLock(fileid, operation, lock, acctok, overridefilename=None):
-    '''Retrieves and logs a lock for a given file: returns the lock and its holder, or (None, None) if missing'''
+    '''Retrieves and logs a lock for a given file: returns the lock and its holder, or (None, None) if missing
+       TODO use the native lock metadata (breaking change) such as the `mtime` and return the whole lock'''
     encacctok = flask.request.args['access_token'][-20:] if 'access_token' in flask.request.args else 'N/A'
     lockcontent = st.getlock(acctok['endpoint'], overridefilename if overridefilename else acctok['filename'], acctok['userid'])
     if not lockcontent:
@@ -203,7 +204,8 @@ def retrieveWopiLock(fileid, operation, lock, acctok, overridefilename=None):
 
 
 def _makeLock(lock):
-    '''Generates the lock payload given the raw data'''
+    '''Generates the lock payload given the raw data
+    TODO drop the expiration time in favour of the lock native metadata'''
     lockcontent = {}
     lockcontent['wopilock'] = lock
     # append or overwrite the expiration time

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -274,8 +274,8 @@ def storeWopiLock(fileid, operation, lock, oldlock, acctok, isoffice):
                     pass      # lock not found, assume we're clear
             else:
                 # any other error is logged but not raised as this is optimistically not blocking WOPI operations
-                log.warning('msg="%s: unable to store LibreOffice-compatible lock" filename="%s" token="%s" lock="%s" reason="%s"' %
-                            (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
+                log.warning('msg="%s: unable to store LibreOffice-compatible lock" filename="%s" token="%s" reason="%s"' %
+                            (operation.title(), acctok['filename'], flask.request.args['access_token'][-20:], e))
 
     try:
         # now atomically store the lock as encoded JWT

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -381,8 +381,8 @@ def storeWopiFile(request, retrievedlock, acctok, xakey, targetname=''):
         st.setlock(acctok['endpoint'], targetname, acctok['userid'], acctok['appname'], encodeLock(retrievedlock))
 
 
-def getuserhome(username):
-    '''Returns the path to the "home" directory for a given user.
-    TODO This is CERN/EOS-specific, to be removed once locking is fully implemented
-    and the logic to store webconflict files can be dropped.'''
-    return '/eos/user/%s/%s' % (username[0], username)
+def getconflictpath(username):
+    '''Returns the path to a suitable conflict path directory for a given user'''
+    if not srv.conflictpath:
+        return None
+    return srv.conflictpath.replace('user_initial', username[0]).replace('username', username)

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -135,7 +135,6 @@ def generateAccessToken(userid, fileid, viewmode, user, folderurl, endpoint, app
     except IOError as e:
         log.info('msg="Requested file not found or not a file" fileid="%s" error="%s"' % (fileid, e))
         raise
-    # if write access is requested, probe whether there's already a lock file coming from Desktop applications
     exptime = int(time.time()) + srv.tokenvalidity
     if not appediturl:
         # deprecated: for backwards compatibility, work out the URLs from the discovered app endpoints
@@ -165,7 +164,7 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefilename=Non
     encacctok = flask.request.args['access_token'][-20:] if 'access_token' in flask.request.args else 'N/A'
 
     # if required, check if a non-WOPI office lock exists for this file
-    checkext = srv.config.get('general', 'detectexternallock', fallback='True').upper() == 'TRUE'
+    checkext = srv.config.get('general', 'detectexternallocks', fallback='True').upper() == 'TRUE'
     lolock = lolockstat = None
     if checkext and os.path.splitext(acctok['filename'])[1] not in srv.nonofficetypes:
         try:
@@ -263,7 +262,7 @@ def storeWopiLock(fileid, operation, lock, oldlock, acctok):
         return makeConflictResponse(operation, 'External App', lock, oldlock, acctok['filename'], \
                                     'The file got moved or deleted')
 
-    if srv.config.get('general', 'detectexternallock', fallback='True').upper() == 'TRUE' and \
+    if srv.config.get('general', 'detectexternallocks', fallback='True').upper() == 'TRUE' and \
        os.path.splitext(acctok['filename'])[1] not in srv.nonofficetypes:
         try:
             # create a LibreOffice-compatible lock file for interoperability purposes, making sure to

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -23,6 +23,8 @@ EOSVERSIONPREFIX = '.sys.v#.'
 
 EXCL_XATTR_MSG = 'exclusive set for existing attribute'
 
+LOCKKEY = 'iop.lock'    # this is to be compatible with the (future) Lock API in Reva
+
 # module-wide state
 config = None
 log = None
@@ -324,6 +326,25 @@ def unlock(endpoint, filepath, userid, _appname):
     except IOError:
         pass
     rmxattr(endpoint, filepath, userid, common.LOCKKEY)
+
+
+def setlock(endpoint, filepath, userid, value):
+    '''Set the lock as an xattr with the special option "c" (create-if-not-exists) on behalf of the given userid'''
+    try:
+        setxattr(endpoint, filepath, userid, LOCKKEY, str(value) + '&mgm.option=c')
+    except IOError as e:
+        if 'exclusive set for exsisting attribute' in str(e):
+            raise IOError('File exists and islock flag requested')
+
+
+def getlock(endpoint, filepath, userid):
+    '''Get the lock metadata as an xattr on behalf of the given userid'''
+    return getxattr(endpoint, filepath, userid, LOCKKEY)
+
+
+def unlock(endpoint, filepath, userid):
+    '''Remove the lock as an xattr on behalf of the given userid'''
+    rmxattr(endpoint, filepath, userid, LOCKKEY)
 
 
 def readfile(endpoint, filepath, userid):

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -23,8 +23,6 @@ EOSVERSIONPREFIX = '.sys.v#.'
 
 EXCL_XATTR_MSG = 'exclusive set for existing attribute'
 
-LOCKKEY = 'iop.lock'    # this is to be compatible with the (future) Lock API in Reva
-
 # module-wide state
 config = None
 log = None
@@ -326,25 +324,6 @@ def unlock(endpoint, filepath, userid, _appname):
     except IOError:
         pass
     rmxattr(endpoint, filepath, userid, common.LOCKKEY)
-
-
-def setlock(endpoint, filepath, userid, value):
-    '''Set the lock as an xattr with the special option "c" (create-if-not-exists) on behalf of the given userid'''
-    try:
-        setxattr(endpoint, filepath, userid, LOCKKEY, str(value) + '&mgm.option=c')
-    except IOError as e:
-        if 'exclusive set for exsisting attribute' in str(e):
-            raise IOError('File exists and islock flag requested')
-
-
-def getlock(endpoint, filepath, userid):
-    '''Get the lock metadata as an xattr on behalf of the given userid'''
-    return getxattr(endpoint, filepath, userid, LOCKKEY)
-
-
-def unlock(endpoint, filepath, userid):
-    '''Remove the lock as an xattr on behalf of the given userid'''
-    rmxattr(endpoint, filepath, userid, LOCKKEY)
 
 
 def readfile(endpoint, filepath, userid):

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -290,23 +290,36 @@ def getlock(endpoint, filepath, userid):
 
 def refreshlock(endpoint, filepath, userid, appname, value):
     '''Refresh the lock value as an xattr'''
-    log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     l = getlock(endpoint, filepath, userid)
     if not l:
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is not locked'))
         raise IOError('File was not locked')
     if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
         raise IOError('File is locked by %s' % l['app_name'])
+    log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     # this is non-atomic, but the lock was already held
     setxattr(endpoint, filepath, userid, common.LOCKKEY, common.genrevalock(appname, value), None)
 
 
-def unlock(endpoint, filepath, userid, _appname, value):
+def unlock(endpoint, filepath, userid, appname, value):
     '''Remove a lock as an xattr'''
+    l = getlock(endpoint, filepath, userid)
+    if not l:
+        log.warning('msg="Failed to unlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is not locked'))
+        raise IOError('File was not locked')
+    if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to unlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
+        raise IOError('File is locked by %s' % l['app_name'])
     log.debug('msg="Invoked unlock" filepath="%s" value="%s' % (filepath, value))
     rmxattr(endpoint, filepath, userid, common.LOCKKEY, None)
 
 
-def readfile(endpoint, filepath, userid):
+def readfile(endpoint, filepath, userid, _lockid):
     '''Read a file via xroot on behalf of the given userid. Note that the function is a generator, managed by Flask.'''
     log.debug('msg="Invoking readFile" filepath="%s"' % filepath)
     with XrdClient.File() as f:

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -3,8 +3,7 @@ xrootiface.py
 
 eos-xrootd interface for the IOP WOPI server
 
-Author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
-Contributions: Michael.DSilva@aarnet.edu.au
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import time

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -118,7 +118,7 @@ def init(inconfig, inlog):
     global endpointoverride     # pylint: disable=global-statement
     global defaultstorage       # pylint: disable=global-statement
     global homepath             # pylint: disable=global-statement
-    config = inconfig
+    common.config = config = inconfig
     log = inlog
     endpointoverride = config.get('xroot', 'endpointoverride', fallback='')
     defaultstorage = config.get('xroot', 'storageserver')
@@ -272,7 +272,7 @@ def setlock(endpoint, filepath, userid, appname, value):
     '''Set a lock as an xattr with the given value metadata and appname as holder.
     The special option "c" (create-if-not-exists) is used to be atomic'''
     try:
-        log.debug('msg="Invoked setlock" filepath="%s"' % filepath)
+        log.debug('msg="Invoked setlock" filepath="%s" value="%s"' % (filepath, value))
         setxattr(endpoint, filepath, userid, common.LOCKKEY, common.genrevalock(appname, value) + '&mgm.option=c')
     except IOError as e:
         if EXCL_XATTR_MSG in str(e):
@@ -289,19 +289,19 @@ def getlock(endpoint, filepath, userid):
 
 def refreshlock(endpoint, filepath, userid, appname, value):
     '''Refresh the lock value as an xattr'''
-    log.debug('msg="Invoked refreshlock" filepath="%s"' % filepath)
+    log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     l = getlock(endpoint, filepath, userid)
     if not l:
         raise IOError('File was not locked')
-    if l['h'] != appname and l['h'] != 'wopi':
-        raise IOError('File is locked by %s' % l['h'])
+    if l['app_name'] != appname and l['app_name'] != 'wopi':
+        raise IOError('File is locked by %s' % l['app_name'])
     # this is non-atomic, but the lock was already held
     setxattr(endpoint, filepath, userid, common.LOCKKEY, common.genrevalock(appname, value))
 
 
-def unlock(endpoint, filepath, userid, _appname):
+def unlock(endpoint, filepath, userid, _appname, value):
     '''Remove a lock as an xattr'''
-    log.debug('msg="Invoked unlock" filepath="%s"' % filepath)
+    log.debug('msg="Invoked unlock" filepath="%s" value="%s' % (filepath, value))
     rmxattr(endpoint, filepath, userid, common.LOCKKEY)
 
 

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -210,7 +210,7 @@ def index():
       <html><head><title>ScienceMesh WOPI Server</title></head>
       <body>
       <div align="center" style="color:#000080; padding-top:50px; font-family:Verdana; size:11">
-      This is the ScienceMesh IOP <a href=http://wopi.readthedocs.io>WOPI</a> server to support online office-like editors.<br>
+      This is the ScienceMesh IOP <a href=https://github.com/cs3org/wopiserver#readme>WOPI</a> server to support online office-like editors.<br>
       The service includes support for non-WOPI-native apps through a bridge extension.<br>
       To use this service, please log in to your EFSS Storage and click on a supported document.</div>
       <div style="position: absolute; bottom: 10px; left: 10px; width: 99%%;"><hr>

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -124,7 +124,7 @@ class Wopi:
                     raise
             cls.wopiurl = cls.config.get('general', 'wopiurl')
             cls.conflictpath = cls.config.get('general', 'conflictpath', fallback='/')
-            cls.recoverypath = cls.config.get('general', 'recoverypath', fallback='/var/spool/wopirecovery')
+            cls.recoverypath = cls.config.get('io', 'recoverypath', fallback='/var/spool/wopirecovery')
             try:
                 os.makedirs(cls.recoverypath)
             except FileExistsError as e:
@@ -433,7 +433,7 @@ def wopiFilesPost(fileid):
     except KeyError as e:
         Wopi.log.warning('msg="Missing argument" client="%s" requestedUrl="%s" error="%s" token="%s"' %
                          (flask.request.remote_addr, flask.request.base_url, e, flask.request.args.get('access_token')))
-        return 'Missing argument: %s' % e, http.client.BAD_REQUEST
+        return 'Missing argument', http.client.BAD_REQUEST
 
 
 @Wopi.app.route("/wopi/files/<fileid>/contents", methods=['POST'])
@@ -443,7 +443,7 @@ def wopiPutFile(fileid):
 
 
 #
-# IOP lock endpoints
+# interoperable lock endpoints
 #
 @Wopi.app.route("/wopi/cbox/lock", methods=['GET', 'POST'])
 @Wopi.metrics.counter('lock_by_ext', 'Number of /lock calls by file extension',

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -123,10 +123,10 @@ class Wopi:
                     cls.log.error('msg="Failed to open the provided certificate or key to start in https mode"')
                     raise
             cls.wopiurl = cls.config.get('general', 'wopiurl')
-            if cls.config.has_option('general', 'lockpath'):
-                cls.lockpath = cls.config.get('general', 'lockpath')
+            if cls.config.has_option('general', 'conflictpath'):
+                cls.conflictpath = cls.config.get('general', 'conflictpath')
             else:
-                cls.lockpath = ''
+                cls.conflictpath = None
             _ = cls.config.get('general', 'downloadurl')   # make sure this is defined
             # WOPI proxy configuration (optional)
             cls.wopiproxy = cls.config.get('general', 'wopiproxy', fallback='')

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -4,7 +4,7 @@ wopiserver.py
 
 The Web-application Open Platform Interface (WOPI) gateway for the ScienceMesh IOP
 
-Author: Giuseppe Lo Presti (@glpatcern), CERN/IT-ST
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 Contributions: see README.md
 '''
 

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -123,10 +123,12 @@ class Wopi:
                     cls.log.error('msg="Failed to open the provided certificate or key to start in https mode"')
                     raise
             cls.wopiurl = cls.config.get('general', 'wopiurl')
-            if cls.config.has_option('general', 'conflictpath'):
-                cls.conflictpath = cls.config.get('general', 'conflictpath')
-            else:
-                cls.conflictpath = None
+            cls.conflictpath = cls.config.get('general', 'conflictpath', fallback='/')
+            cls.recoverypath = cls.config.get('general', 'recoverypath', fallback='/var/spool/wopirecovery')
+            try:
+                os.makedirs(cls.recoverypath)
+            except FileExistsError as e:
+                pass
             _ = cls.config.get('general', 'downloadurl')   # make sure this is defined
             # WOPI proxy configuration (optional)
             cls.wopiproxy = cls.config.get('general', 'wopiproxy', fallback='')

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -404,8 +404,9 @@ def iopWopiTest():
         return 'Missing arguments', http.client.BAD_REQUEST
     if Wopi.useHttps:
         return 'WOPI validator not supported in https mode', http.client.BAD_REQUEST
-    inode, acctok = utils.generateAccessToken(usertoken, filepath, utils.ViewMode.READ_WRITE, ('test', usertoken), '/',
-                                              endpoint, ('WOPI validator', 'http://fortestonly/', 'http://fortestonly/'))
+    inode, acctok = utils.generateAccessToken(usertoken, filepath, utils.ViewMode.READ_WRITE, ('test', usertoken),
+                                              'http://folderurlfortestonly/', endpoint,
+                                              ('WOPI validator', 'http://fortestonly/', 'http://fortestonly/'))
     Wopi.log.info('msg="iopWopiTest: preparing test via WOPI validator" client="%s"' % req.remote_addr)
     return '-e WOPI_URL=http://localhost:%d/wopi/files/%s -e WOPI_TOKEN=%s' % (Wopi.port, inode, acctok)
 

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -118,7 +118,7 @@ class TestStorage(unittest.TestCase):
     '''Writes a binary file and reads it back, validating that the content matches'''
     self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, None)
     content = ''
-    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid):
+    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
       self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
       content += chunk.decode('utf-8')
     self.assertEqual(content, 'bla', 'File test.txt should contain the string "bla"')
@@ -129,7 +129,7 @@ class TestStorage(unittest.TestCase):
     content = 'bla\n'
     self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, None)
     content = ''
-    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid):
+    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
       self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
       content += chunk.decode('utf-8')
     self.assertEqual(content, 'bla\n', 'File test.txt should contain the text "bla\\n"')
@@ -139,7 +139,7 @@ class TestStorage(unittest.TestCase):
     '''Writes an empty file and reads it back, validating that the read does not fail'''
     content = ''
     self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, None)
-    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid):
+    for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
       self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
       content += chunk.decode('utf-8')
     self.assertEqual(content, '', 'File test.txt should be empty')
@@ -147,7 +147,7 @@ class TestStorage(unittest.TestCase):
 
   def test_read_nofile(self):
     '''Test reading of a non-existing file'''
-    readex = next(self.storage.readfile(self.endpoint, self.homepath + '/hopefullynotexisting', self.userid))
+    readex = next(self.storage.readfile(self.endpoint, self.homepath + '/hopefullynotexisting', self.userid, None))
     self.assertIsInstance(readex, IOError, 'readfile returned %s' % readex)
     self.assertEqual(str(readex), ENOENT_MSG, 'readfile returned %s' % readex)
 

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -209,11 +209,15 @@ class TestStorage(unittest.TestCase):
     self.assertIsInstance(statInfo, dict)
     self.storage.setlock(self.endpoint, self.homepath + '/testlock', self.userid, 'testlock')
     l = self.storage.getlock(self.endpoint, self.homepath + '/testlock', self.userid)
-    self.assertEqual(l, 'testlock')
+    self.assertIsInstance(l, dict)
+    self.assertEqual(l['lock_id'], 'testlock')
+    self.assertEqual(l['app_name'], 'myapp')
+    self.assertIsInstance(l['expiration'], dict)
+    self.assertIsInstance(l['expiration']['seconds'], int)
     with self.assertRaises(IOError) as context:
       self.storage.setlock(self.endpoint, self.homepath + '/testlock', self.userid, 'testlock2')
     self.assertIn(EXCL_ERROR, str(context.exception))
-    self.storage.unlock(self.endpoint, self.homepath + '/testlock', self.userid, 'myapp')
+    self.storage.unlock(self.endpoint, self.homepath + '/testlock', self.userid, 'myapp', 'testlock')
     self.storage.removefile(self.endpoint, self.homepath + '/testlock', self.userid)
 
   def test_refresh_lock(self):
@@ -232,8 +236,10 @@ class TestStorage(unittest.TestCase):
     self.storage.refreshlock(self.endpoint, self.homepath + '/testrlock', self.userid, 'myapp', 'testlock2')
     l = self.storage.getlock(self.endpoint, self.homepath + '/testrlock', self.userid)
     self.assertIsInstance(l, dict)
-    self.assertEqual(l['md'], 'testlock2')
-    self.assertEqual(l['h'], 'myapp')
+    self.assertEqual(l['lock_id'], 'testlock2')
+    self.assertEqual(l['app_name'], 'myapp')
+    self.assertIsInstance(l['expiration'], dict)
+    self.assertIsInstance(l['expiration']['seconds'], int)
     with self.assertRaises(IOError) as context:
       self.storage.refreshlock(self.endpoint, self.homepath + '/testrlock', self.userid, 'myapp2', 'testlock2')
     self.assertIn('File is locked by myapp', str(context.exception))

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -4,6 +4,8 @@ test_storageiface.py
 Basic unit testing of the storage interfaces. To run them, please make sure the
 wopiserver-test.conf is correctly configured (see /README.md). The storage layer
 to be tested can be overridden by the WOPI_STORAGE env variable.
+
+Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
 import unittest

--- a/test/wopi-validator.md
+++ b/test/wopi-validator.md
@@ -1,15 +1,19 @@
-# How to run the wopi-validator on a local setup for testing
+## How to run the wopi-validator on a local setup for testing
 
 These notes have been adaped from the enterprise ownCloud WOPI implementation, credits to @deepdiver1975.
 
 1. Setup your WOPI server as well as Reva as required. Make sure the WOPI storage interface unit tests pass.
 
-2. Create an empty file named `test.wopitest` in the user folder, e.g. `touch /var/tmp/reva/einstein/test.wopitest` for a local Reva setup.
+2. Create an empty folder and touch an file named `test.wopitest` in that folder. For a local Reva setup:
 
-3. Generate a WOPI URL and token for that file, e.g. `wopiopen.py /test.wopitest 1000 1000`. Remote setups would require appropriate userids and file paths.
+   `mkdir /var/tmp/reva/data/einstein/wopivalidator && touch /var/tmp/reva/data/einstein/wopivalidator/test.wopitest`.
 
-4. Amend the `WOPI_URL` env variable such that it looks like `http://localhost:<wopiport>/wopi/files/<fileid>`. Note the hardcoded `localhost`.
+3. Ensure you run your WOPI server in http mode, that is you have `usehttps = no` in your configuration.
 
-5. Run the testsuite (you can select a specific test group with e.g. `-e WOPI_TESTGROUP=FileVersion`):
-`docker run --add-host="localhost:<your_external_wopiserver_IP>" -e WOPI_URL=$WOPI_URL -e WOPI_TOKEN=$WOPI_TOKEN deepdiver/wopi-validator-core-docker:use-different-branch-to-make-ci-finally-green`
+4. Generate the input for the test suite:
 
+   `curl -H "Authorization: Bearer <wopisecret>" "http://your_wopi_server:port/wopi/iop/test?filepath=<your_file>&endpoint=<your_storage_endpoint>&usertoken=<your_user_credentials_or_id>"`
+
+5. Run the testsuite (you can select a specific test group passing as well e.g. `-e WOPI_TESTGROUP=FileVersion`):
+
+   `docker run --add-host="localhost:<your_external_wopiserver_IP>" <output from step 4> deepdiver/wopi-validator-core-docker:latest`

--- a/test/wopi-validator.md
+++ b/test/wopi-validator.md
@@ -16,4 +16,4 @@ These notes have been adaped from the enterprise ownCloud WOPI implementation, c
 
 5. Run the testsuite (you can select a specific test group passing as well e.g. `-e WOPI_TESTGROUP=FileVersion`):
 
-   `docker run --add-host="localhost:<your_external_wopiserver_IP>" <output from step 4> deepdiver/wopi-validator-core-docker:latest`
+   `docker run --rm --add-host="localhost:<your_external_wopiserver_IP>" <output from step 4> deepdiver/wopi-validator-core-docker:latest`

--- a/test/wopiserver-test.conf
+++ b/test/wopiserver-test.conf
@@ -1,6 +1,7 @@
 [general]
 storagetype = local
 port = 8880
+wopilockexpiration = 10
 
 [security]
 usehttps = no

--- a/wopiserver.Dockerfile
+++ b/wopiserver.Dockerfile
@@ -2,7 +2,7 @@
 #
 # Build: make docker or docker-compose -f wopiserver.yaml build --build-arg VERSION=`git describe | sed 's/^v//'` wopiserver
 
-FROM python:3.9
+FROM python:3.10
 
 ARG VERSION=latest
 

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -57,6 +57,13 @@ wopilockexpiration = 3600
 # on-premise setups.
 #wopilockstrictcheck = False
 
+# Detection of external Microsoft Office or LibreOffice locks. By default, lock files
+# compatible with Office for Desktop applications are detected, assuming that the
+# underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
+# and SetLock operations return such locks and prevent online apps from entering edit mode.
+# This feature can be disabled in order to operate a pure WOPI server for online apps.
+#detectexternallock = True
+
 # Location of the webconflict files. By default, such files are stored in the same path
 # as the original file. If that fails (e.g. because of missing permissions),
 # an attempt is made to store such files in this path if specified, otherwise

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -57,12 +57,18 @@ wopilockexpiration = 3600
 # on-premise setups.
 #wopilockstrictcheck = False
 
-# Location of the webconflict files. By default, such files are stored
-# in the same path as the original file. If that fails, and a path is provided
-# here, an attempt is made to store such files in there.
+# Location of the webconflict files. By default, such files are stored in the same path
+# as the original file. If that fails (e.g. because of missing permissions),
+# an attempt is made to store such files in this path if specified, otherwise
+# the system falls back to the recovery space (cf. below).
 # The keywords <user_initial> and <username> are replaced with the actual username's
 # initial letter and the actual username, respectively.
 #conflictpath = /your_storage/home/user_initial/username
+
+# Path to a recovery space in case of failures when reaching the remote storage.
+# This is expected to be a local path, and it is provided in order to ease user support.
+# Defaults to the indicated spool folder.
+#recoverypath = /var/spool/wopirecovery
 
 # Enable support of rename operations from WOPI apps. This is currently
 # disabled by default as it has been observed that both MS Office and Collabora

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -57,32 +57,28 @@ wopilockexpiration = 3600
 # on-premise setups.
 #wopilockstrictcheck = False
 
-# Detection of external Microsoft Office or LibreOffice locks. By default, lock files
-# compatible with Office for Desktop applications are detected, assuming that the
-# underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
-# and SetLock operations return such locks and prevent online apps from entering edit mode.
-# This feature can be disabled in order to operate a pure WOPI server for online apps.
-#detectexternallock = True
-
-# Location of the webconflict files. By default, such files are stored in the same path
-# as the original file. If that fails (e.g. because of missing permissions),
-# an attempt is made to store such files in this path if specified, otherwise
-# the system falls back to the recovery space (cf. below).
-# The keywords <user_initial> and <username> are replaced with the actual username's
-# initial letter and the actual username, respectively.
-#conflictpath = /your_storage/home/user_initial/username
-
-# Path to a recovery space in case of failures when reaching the remote storage.
-# This is expected to be a local path, and it is provided in order to ease user support.
-# Defaults to the indicated spool folder.
-#recoverypath = /var/spool/wopirecovery
-
 # Enable support of rename operations from WOPI apps. This is currently
 # disabled by default as it has been observed that both MS Office and Collabora
 # Online do not play well with this feature.
 #enablerename = False
 
-# WOPI proxy configuration (experimental). Disabled by default.
+# Detection of external Microsoft Office or LibreOffice locks. By default, lock files
+# compatible with Office for Desktop applications are detected, assuming that the
+# underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
+# and SetLock operations return such locks and prevent online apps from entering edit mode.
+# This feature can be disabled in order to operate a pure WOPI server for online apps.
+#detectexternallocks = True
+
+# Location of the webconflict files. By default, such files are stored in the same path
+# as the original file. If that fails (e.g. because of missing permissions),
+# an attempt is made to store such files in this path if specified, otherwise
+# the system falls back to the recovery space (cf. io|recoverypath).
+# The keywords <user_initial> and <username> are replaced with the actual username's
+# initial letter and the actual username, respectively, so you can use e.g.
+# /your_storage/home/user_initial/username
+#conflictpath = /
+
+# ownCloud's WOPI proxy configuration. Disabled by default.
 #wopiproxy = https://external-wopi-proxy.org
 #wopiproxykey = key_for_proxy_jwt_encoding
 #proxiedappname = name_of_your_proxied_app
@@ -124,6 +120,11 @@ wopikey = /etc/grid-security/host.key
 [io]
 # Size used for buffered reads [bytes]
 chunksize = 4194304
+
+# Path to a recovery space in case of I/O errors when reaching to the remote storage.
+# This is expected to be a local path, and it is provided in order to ease user support.
+# Defaults to the indicated spool folder.
+#recoverypath = /var/spool/wopirecovery
 
 
 [xroot]

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -57,10 +57,12 @@ wopilockexpiration = 3600
 # on-premise setups.
 #wopilockstrictcheck = False
 
-# Location of the lock files. Currently, two modes are supported:
-# if a path is provided, all locks will be stored there with a hashed name,
-# otherwise the lock is stored on the same path as the original file.
-#lockpath = /your_storage/wopilocks
+# Location of the webconflict files. By default, such files are stored
+# in the same path as the original file. If that fails, and a path is provided
+# here, an attempt is made to store such files in there.
+# The keywords <user_initial> and <username> are replaced with the actual username's
+# initial letter and the actual username, respectively.
+#conflictpath = /your_storage/home/user_initial/username
 
 # Enable support of rename operations from WOPI apps. This is currently
 # disabled by default as it has been observed that both MS Office and Collabora

--- a/wopiserver.yaml
+++ b/wopiserver.yaml
@@ -26,6 +26,7 @@ services:
       - config:/etc/wopi
       - storage:/var/wopi_local_storage
       - logs:/var/log/wopi
+      - recovery:/var/spool/wopirecovery
     healthcheck:
       test: ["CMD", "curl", "--insecure", "http://localhost:8880"]
       interval: 600s
@@ -42,4 +43,5 @@ volumes:
   config:
   storage:
   logs:
+  recovery:
 


### PR DESCRIPTION
This PR introduces a lock API in the storage interfaces and uses it throughout the WOPI logic instead of directly creating lock files.

The lock API is implemented in the xrootd and local interfaces. ~Once https://github.com/cs3org/cs3apis/pull/160 is merged and implemented in Reva, the cs3iface will also be implemented.~ Edit: this was tested in CERNBox QA.

Along with this enhancement, all cases of failures or permission issues when saving a file have been identified and an attempt is made to save a copy to a configured local storage in order to ease later recovery by service operations.
The same process is performed by the bridge extension: this fixes https://github.com/cs3org/wopiserver/issues/39.

Highlights of the implementation:
* Lock operations are now clearly separated in the WOPI code, and abstracted by the storage layers.
* The xrootd and localfs implementations use xattrs. The xattr content is compatible with the Reva/eos implementation, and this is of course deliberate as we're still running the wopiserver in production over xrootd for backwards compatibility reasons.
* The storage operations that imply modifications (write, set/rm attr, rename) now also have a lockid argument. This is not enforced anywhere but we expect to have Reva enforce it in the future (cf. cs3apis#162).
* SetLock is protected against race conditions with itself, but the whole wopiserver logic does suffer (as it did - so not a regression) from a race condition in the following case:
  - Precondition: a file is locked but the lock is expired
  - WOPI SetLock logic: 1) read the existing lock, 2) remove it as expired, 3) set a new one
  - Two users doing WOPI SetLock may race between 1 and 3 (usual non-atomic set-after-check).
* Locking single-shared files is fully supported now, i.e. the wopiserver does not assume write permissions in the containing folder. In the only case where this is required, i.e. when generating webconflict files, a `conflictpath` can be configured as a target location: typically for CERN we'd use the user's home path. Those webconflict files ought not to be created any longer once the lock is fully enforced by Reva; yet as users may access the storage via direct mount (outside of Reva), we keep the protection and this logic around it.

Concerning the format of the lock-id payload, we made an attempt to ensure compatibility with WebDAV locks as follows:
* WebDAV specs require to use as lock-id format
  `opaquelocktoken: UUID [Extension]`
  where `Extension` = `path`, and `path` can actually be anything.
* The WOPI server uses therefore: `opaquelocktoken:hardcoded_uuid base64-encoded_wopi_lock`.

This approach allows the WOPI server to uniquely recognize the WOPI locks from anything else as the [hardcoded] UUID would be its signature. Yet, this implementation may change in the future should this format not be suitable for some reasons or should the WebDAV compatibility be ineffective after all.