### PR TITLE
Use waitress http server for production deployments.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ more_itertools
 tuspy
 prometheus-flask-exporter
 cs3apis>=0.1.dev66
+waitress

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -177,7 +177,8 @@ class Wopi:
             try:
                 from waitress import serve
             except ImportError:
-                print("Missing module waitress.")
+                cls.log.fatal('msg="Failed to initialize the service, aborting" error="missing module waitress"')
+                print("Missing module waitress, aborting")
                 raise
 
             serve(cls.app, host='0.0.0.0', port=cls.port)

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -30,12 +30,6 @@ except ImportError:
     print("Missing modules, please install dependencies with `pip3 install -f requirements.txt`")
     raise
 
-try:
-    from waitress import serve
-except ImportError:
-    print("Missing module waitress.")
-    raise
-
 import core.wopi
 import core.discovery
 import core.ioplocks
@@ -180,6 +174,12 @@ class Wopi:
                          (cls.port, cls.wopiurl, WOPISERVERVERSION))
 
         if cls.config.get('general', 'internalserver', fallback='flask') == 'waitress':
+            try:
+                from waitress import serve
+            except ImportError:
+                print("Missing module waitress.")
+                raise
+
             serve(cls.app, host='0.0.0.0', port=cls.port)
         else:
             cls.app.run(host='0.0.0.0', port=cls.port)

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -26,6 +26,10 @@ port = 8880
 # URL of your WOPI server or your HA proxy in front of it
 #wopiurl = https://your-wopi-server.org:8443
 
+# The internal server to use. Set to waitress for production installations.
+# Leave commented to use the default flask server.
+# internalserver = waitress
+
 # URL for direct download of files. The complete URL that is sent
 # to clients will include the access_token argument
 #downloadurl = https://your-wopi-server.org/wopi/cbox/download


### PR DESCRIPTION
To enable the waitress server for production setups, set the new config option `internalserver` to `waitress`.

See https://dev.to/thetrebelcc/how-to-run-a-flask-app-over-https-using-waitress-and-nginx-2020-235c
for explanation.