### PR TITLE
logrotate: Use reload-or-try-restart instead.

### DIFF
--- a/wopiserver.logrotate
+++ b/wopiserver.logrotate
@@ -5,6 +5,6 @@
   missingok
   rotate 380
   postrotate
-    systemctl restart wopiserver
+    systemctl reload-or-try-restart wopiserver
   endscript
 }


### PR DESCRIPTION
using "restart" on logrotate files is never an appropiate action
as the service should only be restarted if it was actually running
before logrotate started.
