### PR TITLE
Push lock handling logic to storage interfaces

### DIFF
--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -79,5 +79,18 @@ def retrieverevalock(rawlock):
 
 
 def encodeinode(endpoint, inode):
-    '''Encodes a given endpoint and inode to be used as a safe WOPISrc'''
+    '''Encodes a given endpoint and inode to be used as a safe WOPISrc: endpoint is assumed to already be URL safe'''
     return endpoint + '-' + urlsafe_b64encode(inode.encode()).decode()
+
+
+def validatelock(filepath, appname, oldlock, op, log):
+    '''Common logic for validating locks in the xrootd and local storage interfaces.
+       Duplicates some logic implemented in Reva for the cs3 storage interface'''
+    if not oldlock:
+        log.warning('msg="Failed to %s" filepath="%s" appname="%s" reason="%s"' %
+                    (op, filepath, appname, 'File was not locked or lock had expired'))
+        raise IOError('File was not locked or lock had expired')
+    if oldlock['app_name'] != appname and oldlock['app_name'] != 'wopi':
+        log.warning('msg="Failed to %s" filepath="%s" appname="%s" reason="%s"' %
+                    (op, filepath, appname, 'File is locked by %s' % oldlock['app_name']))
+        raise IOError('File is locked by %s' % oldlock['app_name'])

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -102,10 +102,10 @@ def rmxattr(_endpoint, filepath, _userid, key, _lockid):
         raise IOError(e)
 
 
-def setlock(endpoint, filepath, _userid, appname, value):
+def setlock(endpoint, filepath, userid, appname, value):
     '''Set the lock as an xattr on behalf of the given userid'''
     log.debug('msg="Invoked setlock" filepath="%s" value="%s"' % (filepath, value))
-    if not getxattr(endpoint, filepath, '0:0', common.LOCKKEY):
+    if not getlock(endpoint, filepath, userid):
         # we do not protect from race conditions here
         setxattr(endpoint, filepath, '0:0', common.LOCKKEY, common.genrevalock(appname, value), None)
     else:

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -127,6 +127,10 @@ def refreshlock(endpoint, filepath, _userid, appname, value):
         log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
                     (filepath, appname, 'File is not locked'))
         raise IOError('File was not locked')
+    if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
+        raise IOError('File is locked by %s' % l['app_name'])
     log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     # this is non-atomic, but the lock was already held
     setxattr(endpoint, filepath, '0:0', common.LOCKKEY, common.genrevalock(appname, value), None)

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -287,6 +287,10 @@ def refreshlock(endpoint, filepath, userid, appname, value):
         log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
                     (filepath, appname, 'File is not locked'))
         raise IOError('File was not locked')
+    if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
+        raise IOError('File is locked by %s' % l['app_name'])
     log.debug('msg="Invoked refreshlock" filepath="%s" value="%s"' % (filepath, value))
     # this is non-atomic, but the lock was already held
     setxattr(endpoint, filepath, userid, common.LOCKKEY, common.genrevalock(appname, value), None)
@@ -299,6 +303,10 @@ def unlock(endpoint, filepath, userid, appname, value):
         log.warning('msg="Failed to unlock" filepath="%s" appname="%s" reason="%s"' %
                     (filepath, appname, 'File is not locked'))
         raise IOError('File was not locked')
+    if l['app_name'] != appname and l['app_name'] != 'wopi':
+        log.warning('msg="Failed to unlock" filepath="%s" appname="%s" reason="%s"' %
+                    (filepath, appname, 'File is locked by %s' % l['app_name']))
+        raise IOError('File is locked by %s' % l['app_name'])
     log.debug('msg="Invoked unlock" filepath="%s" value="%s' % (filepath, value))
     rmxattr(endpoint, filepath, userid, common.LOCKKEY, None)
 

--- a/test/wopiserver-test.conf
+++ b/test/wopiserver-test.conf
@@ -1,7 +1,7 @@
 [general]
 storagetype = local
 port = 8880
-wopilockexpiration = 10
+wopilockexpiration = 2
 
 [security]
 usehttps = no


### PR DESCRIPTION
In this PR some lock handling logic has been removed from the core WOPI logic and delegated to the storage interfaces, in the assumption that the different CS3 storage providers do implement what is required:
* `getlock()` of an expired lock returns `None`
* `refreshlock()` and `setlock()` of an existing or expired lock behave as per CS3API specs
* A lock is not any longer auto-extended based on the last save time from `PutFile` actions.

The xrootd interface has been adapted, but the detection of external locks now depends on the (EOS) storage to fail a `setlock()` operation when a `flock` exists on the file, as the wopiserver cannot tell any longer if a previously found LibreOffice lock is not owned by itself in the general case of no permissions in the folder (single-file share). Yet, the logic to inspect LibreOffice or MS Office lock files is kept in case permissions allow.

For Reva, https://github.com/cs3org/reva/pull/2444 and https://github.com/cs3org/reva/pull/2625 are expected to be merged for this to work.
