### PR TITLE
don't lock again after file upload

### DIFF
--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -394,9 +394,6 @@ def storeWopiFile(request, retrievedlock, acctok, xakey, targetname=''):
     st.writefile(acctok['endpoint'], targetname, acctok['userid'], request.get_data(), encodeLock(retrievedlock))
     # save the current time for later conflict checking: this is never older than the mtime of the file
     st.setxattr(acctok['endpoint'], targetname, acctok['userid'], xakey, int(time.time()), encodeLock(retrievedlock))
-    # and reinstate the lock if existing
-    if retrievedlock:
-        st.setlock(acctok['endpoint'], targetname, acctok['userid'], acctok['appname'], encodeLock(retrievedlock))
 
 
 def getConflictPath(username):


### PR DESCRIPTION
according to the cs3api spec https://github.com/cs3org/cs3apis/blob/main/cs3/storage/provider/v1beta1/provider_api.proto#L151-L158, locking a already locked file fails with `CODE_FAILED_PRECONDITION`. Since the file isn't unlocked at all, we also don't have any reason to lock it again after the upload