### PR TITLE
Refactored PutFile logic

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -381,7 +381,7 @@ def putRelative(fileid, reqheaders, acctok):
         targetName = relTarget
     # either way, we now have a targetName to save the file: attempt to do so
     try:
-        utils.storeWopiFile(flask.request, None, acctok, utils.LASTSAVETIMEKEY, targetName)
+        utils.storeWopiFile(acctok, None, utils.LASTSAVETIMEKEY, targetName)
     except IOError as e:
         utils.storeForRecovery(flask.request.get_data(), acctok['username'], targetName,
                                flask.request.args['access_token'][-20:], e)
@@ -476,7 +476,7 @@ def _createNewFile(fileid, acctok):
     except IOError:
         # indeed the file did not exist, so we write it for the first time
         try:
-            utils.storeWopiFile(flask.request, None, acctok, utils.LASTSAVETIMEKEY)
+            utils.storeWopiFile(acctok, None, utils.LASTSAVETIMEKEY)
             log.info('msg="File stored successfully" action="editnew" user="%s" filename="%s" token="%s"' %
                      (acctok['userid'][-20:], acctok['filename'], flask.request.args['access_token'][-20:]))
             # and we keep track of it as an open file with timestamp = Epoch, despite not having any lock yet.
@@ -518,7 +518,7 @@ def putFile(fileid, acctok):
             # but the previous checks still give the opportunity of a race condition. We just live with it.
             # Also, note we can't get a time resolution better than one second!
             # Anyhow, the EFSS should support versioning for such cases.
-            utils.storeWopiFile(flask.request, retrievedLock, acctok, utils.LASTSAVETIMEKEY)
+            utils.storeWopiFile(acctok, retrievedLock, utils.LASTSAVETIMEKEY)
             log.info('msg="File stored successfully" action="edit" user="%s" filename="%s" token="%s"' %
                      (acctok['userid'][-20:], acctok['filename'], flask.request.args['access_token'][-20:]))
             statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'], versioninv=1)

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -352,11 +352,6 @@ def storeWopiFile(request, retrievedlock, acctok, xakey, targetname=''):
     st.setxattr(acctok['endpoint'], targetname, acctok['userid'], xakey, int(time.time()), encodeLock(retrievedlock))
 
 
-def _getConflictPath(username):
-    '''Returns the path to a suitable conflict path directory for a given user'''
-    return srv.conflictpath.replace('user_initial', username[0]).replace('username', username)
-
-
 def storeAfterConflict(acctok, retrievedlock, lock, reason):
     '''Saves a conflict file in case the original file was externally locked or overwritten.
     The conflicted copy follows the format `<filename>-webconflict-<time>` and might be stored
@@ -372,7 +367,8 @@ def storeAfterConflict(acctok, retrievedlock, lock, reason):
             dorecovery = e
         else:
             # let's try the configured conflictpath instead of the current folder
-            newname = _getConflictPath(acctok['username']) + os.path.sep + os.path.basename(newname)
+            newname = srv.conflictpath.replace('user_initial', acctok['username'][0]).replace('username', acctok['username']) \
+                      + os.path.sep + os.path.basename(newname)
             try:
                 storeWopiFile(flask.request, retrievedlock, acctok, LASTSAVETIMEKEY, newname)
             except IOError as e:


### PR DESCRIPTION
This refactoring improves the handling of conflict when external locks are found, such that in all cases an attempt is made to create a `<filename>-webconflict-<timestamp>` file in some user-accessible space.
