### PR TITLE
Optionally split space from endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ This is work in progress. Refer to [these notes](test/wopi-validator.md).
 
 ## Run the WOPI server locally for development purposes
 
-1. Install all requirements listed in `requirements.txt`
+1. Install all requirements: `pip install -r requirements.txt`
 2. Add log file directory: `sudo mkdir /var/log/wopi/ && sudo chmod a+rwx /var/log/wopi`
 3. Create the folder for the wopi config: `sudo mkdir /etc/wopi/ && sudo chmod a+rwx /etc/wopi`
-4. Create the files `iopsecret` and `wopiscret` in the folder `/etc/wopi/`, create random strings for the secrets
-5. Copy the provided `wopiserver.conf` to `/etc/wopi/wopiserver.defaults.conf`
-6. Create a config file `/etc/wopi/wopiserver.conf`: start from `docker/etc/wopiserver.conf` for a minimal configuration and add from the defaults file as needed
-7. From the WOPI server folder run: `python3 src/wopiserver.py`
+4. Create recoveryfolder: `sudo mkdir /var/spool/wopirecovery && sudo chmod a+rwx /var/spool/wopirecovery`
+5. Create the files `iopsecret` and `wopiscret` in the folder `/etc/wopi/`, create random strings for the secrets
+6. Copy the provided `wopiserver.conf` to `/etc/wopi/wopiserver.defaults.conf`
+7. Create a config file `/etc/wopi/wopiserver.conf`: start from `docker/etc/wopiserver.conf` for a minimal configuration and add from the defaults file as needed
+8. From the WOPI server folder run: `python3 src/wopiserver.py`
 
 ### Test the open-in-app workflow on the local WOPI server
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-grpcio
-grpcio-tools
+grpcio>=1.47.0
+grpcio-tools>=1.47.0
 cygrpc
 flask
 pyOpenSSL
@@ -7,5 +7,5 @@ PyJWT
 requests
 more_itertools
 prometheus-flask-exporter
-cs3apis>=0.1.dev89
+cs3apis>=0.1.dev95
 waitress

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -53,15 +53,22 @@ def getuseridfromcreds(token, _wopiuser):
 def _getcs3reference(endpoint, fileref):
     '''Generates a CS3 reference for a given fileref, covering the following cases:
     absolute path, relative hybrid path, fully opaque fileid'''
+    # try splitting endpoint
+    parts = endpoint.split("$", 2)
+    endpoint = parts[0]
+    space_id = ""
+    if len(parts) == 2:
+        space_id = parts[1]
+
     if fileref.find('/') > 0:
         # assume we have a relative path in the form `<parent_opaque_id>/<base_filename>`,
         # also works if we get `<parent_opaque_id>/<path>/<filename>`
-        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint,
+        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, space_id=space_id,
                                                              opaque_id=fileref[:fileref.find('/')]),
                                path='.' + fileref[fileref.find('/'):])
     else:
         # assume we have an opaque fileid
-        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, opaque_id=fileref), path='.')
+        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, space_id=space_id, opaque_id=fileref), path='.')
     return ref
 
 


### PR DESCRIPTION
We now optionally split the space id from the endpoint. This keeps the wopiserver compatible with reva master and reva edge, where we add the space id with: https://github.com/cs3org/reva/pull/3074