### PR TITLE
Bridge: validate app by source IP and simplify lock structure

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -330,7 +330,7 @@ class SaveThread(threading.Thread):
                     WB.saveresponses[wopisrc] = wopic.jsonify(str(ile)), http.client.INTERNAL_SERVER_ERROR
                     # attempt to save to local storage to help for later recovery: this is a feature of the core wopiserver
                     content, rc = WB.plugins[appname].savetostorage(wopisrc, openfile['acctok'],
-                                                                    False, {'docid': openfile['docid']}, onlyfetch=True)
+                                                                    False, {'doc': openfile['docid']}, onlyfetch=True)
                     if rc == http.client.OK:
                         utils.storeForRecovery(content, 'unknown', wopisrc[wopisrc.rfind('/') + 1:],
                                                openfile['acctok'][-20:], ile)

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -277,11 +277,8 @@ def savetostorage(wopisrc, acctok, isclose, wopilock, onlyfetch=False):
         reply = wopic.handleputfile('PutFile', wopisrc, res)
         if reply:
             return reply
-        if isclose and wopilock['dig'] == 'dirty':
-            h = hashlib.sha1()
-            h.update(mddoc)
         try:
-            wopilock = wopic.refreshlock(wopisrc, acctok, wopilock, digest=(h.hexdigest() if h else 'dirty'))
+            wopilock = wopic.refreshlock(wopisrc, acctok, wopilock, digest='dirty')
             log.info('msg="Save completed" filename="%s" isclose="%s" token="%s"' %
                      (wopilock['fn'], isclose, acctok[-20:]))
             # combine the responses

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -113,7 +113,7 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
         log.error('msg="Exception raised attempting to connect to Etherpad" exception="%s"' % e)
         raise AppFailure
     # generate and return a WOPI lock structure for this document
-    return wopic.generatelock(docid, filemd, h.hexdigest(), None, acctok, False)
+    return wopic.generatelock(docid, filemd, h.hexdigest(), 'epd', acctok, False)
 
 
 # Etherpad to cloud storage

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -6,7 +6,6 @@ A set of WOPI client functions for the WOPI bridge service.
 Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
 '''
 
-import os
 import json
 import http.client
 import requests
@@ -54,11 +53,11 @@ def generatelock(docid, filemd, digest, app, acctok, isclose):
     '''return a dict to be used as WOPI lock, in the format { docid, filename, digest, app, toclose },
        where toclose is like in the openfiles map'''
     return {
-        'docid': '/' + docid.strip('/'),
-        'filename': filemd['BaseFileName'],
-        'digest': digest,
-        'app': app if app else os.path.splitext(filemd['BaseFileName'])[1][1:],
-        'toclose': {acctok[-20:]: isclose},
+        'doc': '/' + docid.strip('/'),
+        'fn': filemd['BaseFileName'],
+        'dig': digest,
+        'app': app,
+        'tocl': {acctok[-20:]: isclose},
     }
 
 
@@ -119,7 +118,7 @@ def refreshlock(wopisrc, acctok, wopilock, digest=None, toclose=None):
     raise InvalidLock('Failed to refresh the lock')
 
 
-def relock(wopisrc, acctok, docid, isclose):
+def relock(wopisrc, acctok, docid, app, isclose):
     '''Relock again a given document and return a valid WOPI lock, or raise InvalidLock otherwise (cf. SaveThread)'''
     # first get again the file metadata
     res = request(wopisrc, acctok, 'GET')
@@ -130,7 +129,7 @@ def relock(wopisrc, acctok, docid, isclose):
     filemd = res.json()
 
     # lock the file again: we assume we are alone as the previous lock had been released
-    wopilock = generatelock(docid, filemd, 'dirty', None, acctok, isclose)
+    wopilock = generatelock(docid, filemd, 'dirty', app, acctok, isclose)
     lockheaders = {
         'X-WOPI-Lock': json.dumps(wopilock),
         'X-WOPI-Override': 'REFRESH_LOCK',

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -106,6 +106,8 @@ def refreshlock(wopisrc, acctok, wopilock, digest=None, toclose=None):
             # merge toclose token lists
             for t in currlock['tocl']:
                 toclose[t] = currlock['tocl'][t] or (t in toclose and toclose[t])
+        if digest:
+            wopilock['dig'] = currlock['dig']
         # retry with the newly got lock
         h, newlock = _getheadersforrefreshlock(acctok, wopilock, digest, toclose)
         res = request(wopisrc, acctok, 'POST', headers=h)

--- a/src/bridge/wopiclient.py
+++ b/src/bridge/wopiclient.py
@@ -143,7 +143,7 @@ def relock(wopisrc, acctok, docid, isclose):
         log.warning('msg="Failed to relock the file" response="%d" token="%s" reason="%s"' %
                     (res.status_code, acctok[-20:], res.headers.get('X-WOPI-LockFailureReason')))
         raise InvalidLock('Failed to relock the file on save, please refresh this page')
-    # relock was successful, return lock: along with noteids univocally associated to files (WOPISrc's),
+    # relock was successful, return lock: along with docids univocally associated to files (WOPISrc's),
     # we are sure no other updates could have been missed
     return wopilock
 

--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -73,7 +73,7 @@ def retrieverevalock(rawlock):
     try:
         return json.loads(urlsafe_b64decode(rawlock + '==').decode())
     except (B64Error, json.JSONDecodeError) as e:
-        raise IOError(e)
+        raise IOError("Unable to parse existing lock: " + str(e))
 
 
 def encodeinode(endpoint, inode):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -51,8 +51,8 @@ def _getfilepath(filepath):
 
 def init(inconfig, inlog):
     '''Init module-level variables'''
-    global config                 # pylint: disable=global-statement
-    global log                        # pylint: disable=global-statement
+    global config               # pylint: disable=global-statement
+    global log                  # pylint: disable=global-statement
     global homepath             # pylint: disable=global-statement
     common.config = config = inconfig
     log = inlog
@@ -255,7 +255,7 @@ def renamefile(endpoint, origfilepath, newfilepath, userid, lockid):
     _checklock('renamefile', endpoint, origfilepath, userid, lockid)
     try:
         os.rename(_getfilepath(origfilepath), _getfilepath(newfilepath))
-    except (FileNotFoundError, PermissionError, OSError) as e:
+    except OSError as e:
         raise IOError(e)
 
 
@@ -264,5 +264,5 @@ def removefile(_endpoint, filepath, _userid, force=False):
        The force argument is irrelevant and ignored for local storage.'''
     try:
         os.remove(_getfilepath(filepath))
-    except (FileNotFoundError, PermissionError, IsADirectoryError, OSError) as e:
+    except OSError as e:
         raise IOError(e)

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -249,10 +249,10 @@ def setLock(fileid, reqheaders, acctok):
                 resp.status_code = http.client.OK
                 resp.headers['X-WOPI-ItemVersion'] = 'v%s' % statInfo['etag']
                 return resp
-            except IOError as e:
+            except IOError as rle:
                 # this is unexpected now
                 log.error('msg="Failed to refresh lock" lockop="%s" filename="%s" token="%s" lock="%s" error="%s"' %
-                          (op.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))
+                          (op.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, rle))
         # any other error is raised
         log.error('msg="Unable to store WOPI lock" lockop="%s" filename="%s" token="%s" lock="%s" error="%s"' %
                   (op.title(), acctok['filename'], flask.request.args['access_token'][-20:], lock, e))


### PR DESCRIPTION
This PR refactors the bridge logic around save and relock operations, as the application is now inferred from the remote IP contacting the save endpoint. This also ensures no unregistered app can interfere with the save workflow, and allows simplifying the lock structure.

At the same time, the `/wopi/bridge/open` endpoint has been removed as it was already deprecated and only used by the old CERNBox UI, which is progressively being replaced by the new OCIS/Reva infrastructure.
