### PR TITLE
First implementation to support the save webhook in Etherpad

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -92,9 +92,9 @@ class WB:
             cls.plugins[p].init(appurl, appinturl, apikey)
             cls.log.info('msg="Imported plugin for application" app="%s" plugin="%s"' % (p, cls.plugins[p]))
         except Exception as e:
-            cls.log.info('msg="Disabled plugin following failed initialization" app="%s" URL="%s" exception="%s"' %
+            cls.log.info('msg="Failed to initialize plugin" app="%s" URL="%s" exception="%s"' %
                          (p, appinturl, e))
-            cls.plugins[p] = None
+            cls.plugins.pop(p, None)   # regardless which step failed, this will remove the failed plugin
             raise ValueError(appname)
 
         # start the thread to perform async save operations if not yet started
@@ -235,7 +235,7 @@ def appsave(docid):
         WB.log.info('msg="BridgeSave: requested action" isclose="%s" docid="%s" app="%s" wopisrc="%s" token="%s"' %
                     (isclose, docid, appname, wopisrc, acctok[-20:]))
     except (KeyError, ValueError) as e:
-        WB.log.error('msg="BridgeSave: malformed or missing metadata" client="%s" headers="%s" exception="%s" error="%s"' %
+        WB.log.error('msg="BridgeSave: malformed/missing metadata or unknown client" client="%s" headers="%s" exception="%s" error="%s"' %
                      (flask.request.remote_addr, flask.request.headers, type(e), e))
         # this should be BAD_REQUEST but requires a change in CodiMD
         return wopic.jsonify('Malformed or missing metadata, could not save. %s' % RECOVER_MSG), http.client.INTERNAL_SERVER_ERROR

--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -201,7 +201,7 @@ def appopen(wopisrc, acctok, appname):
             # user has no write privileges, just fetch the document and push it to the app on a random docid
             wopilock = app.loadfromstorage(filemd, wopisrc, acctok, None)
 
-        redirurl = app.getredirecturl(filemd['UserCanWrite'], wopisrc, acctok, wopilock['doc'],
+        redirurl = app.getredirecturl(filemd['UserCanWrite'], wopisrc, acctok, wopilock['doc'][1:],
                                       urlparse.quote_plus(filemd['UserFriendlyName']))
     except app.AppFailure as e:
         # this can be raised by loadfromstorage or getredirecturl

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -59,12 +59,12 @@ def init(_appurl, _appinturl, _apikey):
 def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     '''Return a valid URL to the app for the given WOPI context'''
     if isreadwrite:
-        return appexturl + docid + '?metadata=' + \
+        return appexturl + '/' + docid + '?metadata=' + \
                urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + \
                '&apiKey=' + apikey + '&displayName=' + displayname
 
     # read-only mode: first check if we have a CodiMD redirection
-    res = requests.head(appurl + docid,
+    res = requests.head(appurl + '/' + docid,
                         params={'apiKey': apikey},
                         verify=sslverify)
     if res.status_code == http.client.FOUND:
@@ -72,7 +72,7 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     # we used to redirect to publish mode or normal view to quickly jump in slide mode depending on the content,
     # but this was based on a bad side effect - here it would require to add:
     # ('/publish' if not _isslides(content) else '') before the '?'
-    return appexturl + docid + '/publish?apiKey=' + apikey
+    return appexturl + '/' + docid + '/publish?apiKey=' + apikey
 
 
 # Cloud storage to CodiMD

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -59,20 +59,20 @@ def init(_appurl, _appinturl, _apikey):
 def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     '''Return a valid URL to the app for the given WOPI context'''
     if isreadwrite:
-        return appexturl + '/' + docid + '?metadata=' + \
-               urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)) + \
-               '&apiKey=' + apikey + '&displayName=' + displayname
+        return '%s/%s?wopiSrc=%s&accessToken=%s&apiKey=%s&displayName=%s&metadata=%s' % \
+            (appexturl, docid, urlparse.quote_plus(wopisrc), acctok, apikey, displayname,
+             urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok)))  # TODO this one is deprecated
 
     # read-only mode: first check if we have a CodiMD redirection
     res = requests.head(appurl + '/' + docid,
                         params={'apiKey': apikey},
                         verify=sslverify)
     if res.status_code == http.client.FOUND:
-        return appexturl + '/s/' + urlparse.urlsplit(res.next.url).path.split('/')[-1] + '?apiKey=' + apikey
+        return '%s/s/%s?apiKey=%s' % (appexturl, urlparse.urlsplit(res.next.url).path.split('/')[-1], apikey)
     # we used to redirect to publish mode or normal view to quickly jump in slide mode depending on the content,
     # but this was based on a bad side effect - here it would require to add:
     # ('/publish' if not _isslides(content) else '') before the '?'
-    return appexturl + '/' + docid + '/publish?apiKey=' + apikey
+    return '%s/%s/publish?apiKey=%s' % (appexturl, docid, apikey)
 
 
 # Cloud storage to CodiMD

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -72,7 +72,7 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     # then pass to Etherpad the required metadata for the save webhook
     try:
         res = requests.post(appurl + '/setEFSSMetadata',
-                            params={'authorID': author['data']['authorID'], 'padID': docid[1:],
+                            params={'authorID': author['data']['authorID'], 'padID': docid,
                                     'metadata': urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok))},
                             verify=sslverify)
         if res.status_code != http.client.OK:
@@ -85,10 +85,10 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
 
     if not isreadwrite:
         # for read-only mode generate a read-only link
-        res = _apicall('getReadOnlyID', {'padID': docid[1:]}, acctok=acctok)
+        res = _apicall('getReadOnlyID', {'padID': docid}, acctok=acctok)
         return appexturl + '/p/%s' % res['data']['readOnlyID']
     # return the URL to the pad
-    return appexturl + '/p%s' % docid
+    return appexturl + '/p/%s' % docid
 
 
 # Cloud storage to Etherpad

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -101,8 +101,6 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
     if res.status_code != http.client.OK:
         raise AppFailure('Unable to fetch file from storage, got HTTP %d' % res.status_code)
     epfile = res.content
-    if not epfile:
-        epfile = b'{}'   # this represents an empty Etherpad file
     try:
         if not docid:
             docid = ''.join([choice(ascii_lowercase) for _ in range(20)])
@@ -112,16 +110,19 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
         # create pad with the given docid as name
         _apicall('createGroupPad', {'groupID': groupid, 'padName': docid, 'text': 'placeholder'},
                  acctok=acctok, raiseonnonzerocode=False)
-        # push content
-        res = requests.post(appurl + '/p/' + docid + '/import',
-                            files={'file': (docid + '.etherpad', epfile)},  # a .etherpad file is imported as raw (JSON) content
-                            params={'apikey': apikey},
-                            verify=sslverify)
-        if res.status_code != http.client.OK:
-            log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
-                      (acctok[-20:], res.status_code, res.content.decode()))
-            raise AppFailure
-        log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
+        if len(epfile) > 0:
+            # push content: a .etherpad file is imported as raw (JSON) content
+            res = requests.post(appurl + '/p/' + docid + '/import',
+                                files={'file': (docid + '.etherpad', epfile, 'application/json')},
+                                params={'apikey': apikey},
+                                verify=sslverify)
+            if res.status_code != http.client.OK:
+                log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
+                        (acctok[-20:], res.status_code, res.content.decode()))
+                raise AppFailure
+            log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
+        else:
+            log.info('msg="Empty document created in Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to Etherpad" method="import" exception="%s"' % e)
         raise AppFailure

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -86,9 +86,9 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     if not isreadwrite:
         # for read-only mode generate a read-only link
         res = _apicall('getReadOnlyID', {'padID': docid}, acctok=acctok)
-        return appexturl + '/p/%s' % res['data']['readOnlyID']
+        return appexturl + '/p/%s?userName=%s' % (res['data']['readOnlyID'], displayname)
     # return the URL to the pad
-    return appexturl + '/p/%s' % docid
+    return appexturl + '/p/%s?userName=%s' % (docid, displayname)
 
 
 # Cloud storage to Etherpad

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -88,7 +88,7 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
         res = _apicall('getReadOnlyID', {'padID': docid[1:]}, acctok=acctok)
         return appexturl + '/p/%s' % res['data']['readOnlyID']
     # return the URL to the pad
-    return appexturl + '/p/%s' % docid[1:]
+    return appexturl + '/p%s' % docid
 
 
 # Cloud storage to Etherpad

--- a/src/bridge/etherpad.py
+++ b/src/bridge/etherpad.py
@@ -73,12 +73,14 @@ def getredirecturl(isreadwrite, wopisrc, acctok, docid, displayname):
     try:
         res = requests.post(appurl + '/setEFSSMetadata',
                             params={'authorID': author['data']['authorID'], 'padID': docid,
-                                    'metadata': urlparse.quote_plus('%s?t=%s' % (wopisrc, acctok))},
+                                    'wopiSrc': urlparse.quote_plus(wopisrc), 'accessToken': acctok,
+                                    'apikey': apikey},
                             verify=sslverify)
         if res.status_code != http.client.OK:
             log.error('msg="Failed to call Etherpad" method="setEFSSMetadata" token="%s" response="%d: %s"' %
-                      (acctok[-20:], res.status_code, res.content.decode()))
+                      (acctok[-20:], res.status_code, res.content.decode().replace('"', "'")))
             raise AppFailure
+        log.debug('msg="Called Etherpad" method="setEFSSMetadata" token="%s"' % acctok[-20:])
     except requests.exceptions.ConnectionError as e:
         log.error('msg="Exception raised attempting to connect to Etherpad" method="setEFSSMetadata" exception="%s"' % e)
         raise AppFailure
@@ -118,7 +120,7 @@ def loadfromstorage(filemd, wopisrc, acctok, docid):
                                 verify=sslverify)
             if res.status_code != http.client.OK:
                 log.error('msg="Unable to push document to Etherpad" token="%s" response="%d: %s"' %
-                        (acctok[-20:], res.status_code, res.content.decode()))
+                          (acctok[-20:], res.status_code, res.content.decode()))
                 raise AppFailure
             log.info('msg="Pushed document to Etherpad" docid="%s" token="%s"' % (docid, acctok[-20:]))
         else:

--- a/src/bridge/readme.md
+++ b/src/bridge/readme.md
@@ -3,8 +3,8 @@
 This module includes the code once prototyped at https://github.com/cs3org/wopibridge, to integrate collaborative editors such as CodiMD and Etherpad (partially supported for the time being). The approach is generic to allow for extending the concept to other Office-like applications exposing a minimal load/save REST API.
 
 The module provides two endpoints:
-- `/wopi/bridge/open`   meant to be called by the EFSS with a WOPISrc and a WOPI access token, returns a file displayed in CodiMD
-- `/wopi/bridge/<docid>`   auto-called by the CodiMD backend when some changes are detected on the open document referenced as `<docid>`
+- `/wopi/bridge/<docid>`  auto-called by the app backends when some changes are detected on the open document referenced as `<docid>`
+- `/wopi/bridge/list`  for operators only, it returns a list of all currently opened files in bridge mode
 
 The module implements a stateless server, as all context information is stored in WOPI locks or passed through arguments. Collaborative editing and locking of files is supported by means of the following WOPI APIs:
 * `GetFileInfo`: get all file metadata
@@ -36,6 +36,5 @@ The module implements a stateless server, as all context information is stored i
 
 
 ### Etherpad specifics
-* Support for readonly and read-write files
-* Automatic save still work-in-progress
-
+* Support for readonly and read/write files
+* Automatic save via dedicated `ep_sciencemesh` plugin


### PR DESCRIPTION
This PR includes a minimal complete implementation to support Etherpad. It also includes a change to pass and get `WOPISrc` and `access_token` as separate parameters on the `/wopi/bridge/<docid>` save endpoint, to allow for more flexibility on the apps side.