### PR TITLE
fix UnLockAndRelock and length of resourceIDs

### DIFF
--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -182,7 +182,7 @@ def setlock(endpoint, filepath, userid, appname, value):
                        expiration={'seconds': int(time.time() + ctx['lockexpiration'])})
     req = cs3sp.SetLockRequest(ref=reference, lock=lock)
     res = ctx['cs3gw'].SetLock(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code == cs3code.CODE_FAILED_PRECONDITION:
+    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
         log.info('msg="Invoked setlock on an already locked entity" filepath="%s" appname="%s" trace="%s" reason="%s"' %
                  (filepath, appname, res.status.trace, res.status.message.replace('"', "'")))
         raise IOError(common.EXCL_ERROR)

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -218,6 +218,10 @@ def setLock(fileid, reqheaders, acctok):
                             (op.title(), fn, flask.request.args['access_token'][-20:], e))
 
     try:
+        # If LOCK and oldLock provided this is an UnLockAndRelock operation
+        if op == 'LOCK' and oldLock:
+            st.unlock(acctok['endpoint'], fn, acctok['userid'], acctok['appname'], utils.encodeLock(oldLock))
+
         # LOCK or REFRESH_LOCK: atomically set the lock to the given one, including the expiration time,
         # and return conflict response if the file was already locked
         st.setlock(acctok['endpoint'], fn, acctok['userid'], acctok['appname'], utils.encodeLock(lock))

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -136,7 +136,7 @@ def generateWopiSrc(fileid, proxy=False):
     if not proxy or not srv.wopiproxy:
         return url_quote_plus('%s/wopi/files/%s' % (srv.wopiurl, fileid)).replace('-', '%2D')
     # proxy the WOPI request through an external WOPI proxy service, but only if it was not already proxied
-    if len(fileid) < 50:   # heuristically, proxied fileids are (much) longer than that
+    if len(fileid) < 90:   # heuristically, proxied fileids are (much) longer than that
         log.debug('msg="Generating proxied fileid" fileid="%s" proxy="%s"' % (fileid, srv.wopiproxy))
         fileid = jwt.encode({'u': srv.wopiurl + '/wopi/files/', 'f': fileid}, srv.wopiproxykey, algorithm='HS256')
     else:


### PR DESCRIPTION
# Description

needed to improve #76 

### WOPI Validator
```sh
./Microsoft.Office.WopiValidator -n SuccessfulLockSequence -w https://wopiserver.team.owncloud.works/wopi/files/<fileID> -t <token> -l 1663776371000

Test group: Locks
  Pass: SuccessfulLockSequence
```