### PR TITLE
fix duplicate logging entries

### DIFF
--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -107,10 +107,11 @@ class Wopi:
                 fmt='{"time": "%(asctime)s.%(msecs)03d", "host": "'
                 + hostname + '", "level": "%(levelname)s", "process": "%(name)s", %(message)s}',
                 datefmt='%Y-%m-%dT%H:%M:%S'))
-            cls.app.logger.handlers = [loghandler]
             if cls.config.get('general', 'internalserver', fallback='flask') == 'waitress':
                 cls.log.logger.handlers.clear()
                 logging.getLogger().handlers = [loghandler]
+            else:
+                cls.app.logger.handlers = [loghandler]
             # load the requested storage layer
             storage_layer_import(cls.config.get('general', 'storagetype'))
             # prepare the Flask web app

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -108,6 +108,9 @@ class Wopi:
                 + hostname + '", "level": "%(levelname)s", "process": "%(name)s", %(message)s}',
                 datefmt='%Y-%m-%dT%H:%M:%S'))
             cls.app.logger.handlers = [loghandler]
+            if cls.config.get('general', 'internalserver', fallback='flask') == 'waitress':
+                cls.log.logger.handlers.clear()
+                logging.getLogger().handlers = [loghandler]
             # load the requested storage layer
             storage_layer_import(cls.config.get('general', 'storagetype'))
             # prepare the Flask web app


### PR DESCRIPTION
Background: https://github.com/Pylons/waitress/issues/151

For `waitress` it's required to add a log handler to the root logger (which is recommended in general) otherwise `waitress` will add its own handler. As a result, there exists a waitress handler and a flask handler which are both used for logging.

Result with debug log level:

```Shell
❯ python3 src/wopiserver.py
{"time": "2022-10-11T11:18:20.548", "host": "superion", "level": "INFO", "process": "wopiserver", "module": "wopiserver", "msg": "WOPI Server starting in unsecure/embedded mode", "port": "8880", "wopiurl": "https://your-wopi-server.org:8443", "version": "git"}
{"time": "2022-10-11T11:18:25.721", "host": "superion", "level": "DEBUG", "process": "wopiserver", "module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"}
DEBUG:wopiserver:"module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"
{"time": "2022-10-11T11:18:26.087", "host": "superion", "level": "DEBUG", "process": "wopiserver", "module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"}
DEBUG:wopiserver:"module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"
``` 

To fix it, this PR is removing the flask log handler and adding a proper handler to the root logger if waitress is used.

Result:

```Shell
❯ python3 src/wopiserver.py
{"time": "2022-10-11T11:20:30.725", "host": "superion", "level": "INFO", "process": "wopiserver", "module": "wopiserver", "msg": "WOPI Server starting in unsecure/embedded mode", "port": "8880", "wopiurl": "https://your-wopi-server.org:8443", "version": "git"}
{"time": "2022-10-11T11:20:38.280", "host": "superion", "level": "DEBUG", "process": "wopiserver", "module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"}
{"time": "2022-10-11T11:20:38.639", "host": "superion", "level": "DEBUG", "process": "wopiserver", "module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"}
{"time": "2022-10-11T11:20:39.029", "host": "superion", "level": "DEBUG", "process": "wopiserver", "module": "wopiserver", "msg": "Accessed index page", "client": "127.0.0.1"}
```