### PR TITLE
Implementation of EOS-supported locking

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,7 +30,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide, we further relax this
-        flake8 . --count --exit-zero --max-complexity=15 --max-line-length=130 --statistics
+        flake8 . --count --exit-zero --max-complexity=30 --max-line-length=130 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *pyc
 *rpm
+.cache
 .mypy_cache

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -367,10 +367,10 @@ def removefile(endpoint, filepath, userid, _force=False):
     req = cs3sp.DeleteRequest(ref=reference)
     res = ctx['cs3gw'].Delete(request=req, metadata=[('x-access-token', userid)])
     if res.status.code != cs3code.CODE_OK:
-        if str(res) == common.ENOENT_MSG:
+        if 'path not found' in str(res):
             log.info('msg="Invoked removefile on non-existing file" filepath="%s"' % filepath)
-        else:
-            log.error('msg="Failed to remove file" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                      (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
+            raise IOError(common.ENOENT_MSG)
+        log.error('msg="Failed to remove file" filepath="%s" trace="%s" code="%s" reason="%s"' %
+                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
         raise IOError(res.status.message)
     log.debug('msg="Invoked removefile" result="%s"' % res)

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -56,7 +56,10 @@ def _getcs3reference(endpoint, fileref):
     if len(parts) == 2:
         space_id = parts[1]
 
-    if fileref.find('/') > 0:
+    if fileref.find('/') == 0:
+        # assume we have an absolute path (works in Reva master, not in edge)
+        ref = cs3spr.Reference(path=fileref)
+    elif fileref.find('/') > 0:
         # assume we have a relative path in the form `<parent_opaque_id>/<base_filename>`,
         # also works if we get `<parent_opaque_id>/<path>/<filename>`
         ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, space_id=space_id,
@@ -72,7 +75,7 @@ def authenticate_for_test(userid, userpwd):
     '''Use basic authentication against Reva for testing purposes'''
     authReq = cs3gw.AuthenticateRequest(type='basic', client_id=userid, client_secret=userpwd)
     authRes = ctx['cs3gw'].Authenticate(authReq)
-    log.debug('msg="Authenticated user" res="%s"' % authRes)
+    log.debug('msg="Authenticated user" userid="%s"' % authRes.user.id)
     if authRes.status.code != cs3code.CODE_OK:
         raise IOError('Failed to authenticate as user ' + userid + ': ' + authRes.status.message)
     return authRes.token

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -255,9 +255,8 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
              (filepath, (tend - tstart) * 1000, islock))
 
 
-def renamefile(endpoint, origfilepath, newfilepath, userid, lockid):
+def renamefile(endpoint, origfilepath, newfilepath, _userid, _lockid):
     '''Rename a file from origfilepath to newfilepath on behalf of the given userid.'''
-    common.validatelock(origfilepath, getlock(endpoint, origfilepath, userid), None, lockid, 'renamefile', log)
     try:
         os.rename(_getfilepath(origfilepath), _getfilepath(newfilepath))
     except OSError as e:

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -105,7 +105,10 @@ def statx(endpoint, filepath, userid, versioninv=1):
 def setxattr(endpoint, filepath, userid, key, value, lockid):
     '''Set the extended attribute <key> to <value> on behalf of the given userid'''
     if key != common.LOCKKEY:
-        common.validatelock(filepath, getlock(endpoint, filepath, userid), None, lockid, 'setxattr', log)
+        currlock = getlock(endpoint, filepath, userid)
+        if currlock:
+            # enforce lock only if previously set
+            common.validatelock(filepath, currlock, None, lockid, 'setxattr', log)
     try:
         os.setxattr(_getfilepath(filepath), 'user.' + key, str(value).encode())
     except OSError as e:

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -425,11 +425,12 @@ def storeWopiFile(acctok, retrievedlock, xakey, targetname=''):
 
     writeerror = None
     try:
-        st.writefile(acctok['endpoint'], targetname, acctok['userid'], flask.request.get_data(), encodeLock(retrievedlock))
+        st.writefile(acctok['endpoint'], targetname, acctok['userid'], flask.request.get_data(),
+                    (acctok['appname'], encodeLock(retrievedlock)))
     except IOError as e:
         # in case something goes wrong on write, we still want to setxattr but report this error to the caller
         writeerror = e
-    # save the current time for later conflict checking: this is never older than the mtime of the file
+    # in all cases save the current time for later conflict checking: this is never older than the mtime of the file
     st.setxattr(acctok['endpoint'], targetname, acctok['userid'], xakey, int(time.time()), encodeLock(retrievedlock))
     if writeerror:
         raise writeerror

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -426,9 +426,11 @@ def storeWopiFile(acctok, retrievedlock, xakey, targetname=''):
     writeerror = None
     try:
         st.writefile(acctok['endpoint'], targetname, acctok['userid'], flask.request.get_data(),
-                    (acctok['appname'], encodeLock(retrievedlock)))
+                     (acctok['appname'], encodeLock(retrievedlock)))
     except IOError as e:
-        # in case something goes wrong on write, we still want to setxattr but report this error to the caller
+        if str(e) == common.ACCESS_ERROR:
+            raise
+        # something went wrong on write: we still want to setxattr but report this error to the caller
         writeerror = e
     # in all cases save the current time for later conflict checking: this is never older than the mtime of the file
     st.setxattr(acctok['endpoint'], targetname, acctok['userid'], xakey, int(time.time()), encodeLock(retrievedlock))

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -415,6 +415,9 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
         if 'file has a valid extended attribute lock' in rc.message:
             log.warning('msg="Lock mismatch when writing file" filepath="%s"' % filepath)
             raise IOError(common.LOCK_MISMATCH_ERROR)
+        if common.ACCESS_ERROR in rc.message:
+            log.warning('msg="Access denied when writing file" filepath="%s"' % filepath)
+            raise IOError(common.ACCESS_ERROR)
         # any other failure is reported as is
         log.error('msg="Error opening the file for write" filepath="%s" elapsedTimems="%.1f" error="%s"' %
                   (filepath, (tend-tstart)*1000, rc.message.strip('\n')))

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -438,9 +438,8 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
              (filepath, (tend-tstart)*1000, islock))
 
 
-def renamefile(endpoint, origfilepath, newfilepath, userid, lockid):
+def renamefile(endpoint, origfilepath, newfilepath, userid, _lockid):
     '''Rename a file via a special open from origfilepath to newfilepath on behalf of the given userid.'''
-    common.validatelock(origfilepath, getlock(endpoint, origfilepath, userid), None, lockid, 'renamefile', log)
     _xrootcmd(endpoint, 'file', 'rename', userid, 'mgm.path=' + _getfilepath(origfilepath, encodeamp=True)
               + '&mgm.file.source=' + _getfilepath(origfilepath, encodeamp=True)
               + '&mgm.file.target=' + _getfilepath(newfilepath, encodeamp=True))

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -297,12 +297,11 @@ class TestStorage(unittest.TestCase):
             self.storage.setxattr(self.endpoint, self.homepath + '/testlockop', self.userid, 'testkey', 123, None)
         with self.assertRaises(IOError):
             self.storage.rmxattr(self.endpoint, self.homepath + '/testlockop', self.userid, 'testkey', None)
-        with self.assertRaises(IOError):
-            self.storage.renamefile(self.endpoint, self.homepath + '/testlockop', self.homepath + '/testlockop_renamed',
-                                    self.userid, None)
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/testlockop', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile, lock shall be shared')
-        self.storage.removefile(self.endpoint, self.homepath + '/testlockop', self.userid)
+        self.storage.renamefile(self.endpoint, self.homepath + '/testlockop', self.homepath + '/testlockop_renamed',
+                                self.userid, 'testlock')
+        self.storage.removefile(self.endpoint, self.homepath + '/testlockop_renamed', self.userid)
 
     def test_expired_locks(self):
         '''Test lock operations on expired locks'''

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -295,6 +295,8 @@ class TestStorage(unittest.TestCase):
         with self.assertRaises(IOError):
             self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, None)
         with self.assertRaises(IOError):
+            self.storage.setxattr(self.endpoint, self.homepath + '/testlockop', self.userid, 'testkey', 123, 'mismatchlock')
+        with self.assertRaises(IOError):
             self.storage.setxattr(self.endpoint, self.homepath + '/testlockop', self.userid, 'testkey', 123, None)
         with self.assertRaises(IOError):
             self.storage.rmxattr(self.endpoint, self.homepath + '/testlockop', self.userid, 'testkey', None)
@@ -344,6 +346,7 @@ class TestStorage(unittest.TestCase):
     def test_xattr(self):
         '''Test all xattr methods with special chars'''
         self.storage.writefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, databuf, None)
+        self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123, None)
         self.storage.setlock(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'test app', 'xattrlock')
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123, 'xattrlock')
         v = self.storage.getxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey')

--- a/test/wopiserver-test.conf
+++ b/test/wopiserver-test.conf
@@ -20,9 +20,8 @@ revagateway = cbox-ocisdev-01:9142
 authtokenvalidity = 3600
 sslverify = False
 userid = <login>
-userpwd = <pwd>
 endpoint = <storage uuid or alias>
-storagehomepath = <spaceid>
+storagehomepath = <spaceid or absolute path>
 
 [xroot]
 storageserver = root://eoshomecanary


### PR DESCRIPTION
Internal reference: https://its.cern.ch/jira/browse/CERNBOX-3016

Through validation tests, it turns out that rename operations (`MoveRequest` in CS3 API terms) ~~must be supported regardless if a file is locked~~ - edit: renames may still need a lock, regardless how Microsoft Office behaves. The test suite was amended to take that into account. Similarly, the wopiserver needs to be able to set an xattr on an unlocked file, but be denied if the file is locked and the lock does not match. This was incorporated as well in the test suite.

Validation tests:
- [x] local interface (CI)
- [x] xroot interface
~~- [ ] cs3 interface~~
- [x] MS WOPI validator tests on top of xroot
~~- [ ] MS WOPI validator tests on top of cs3~~

Update: as renames were not changed, and as right now the CS3 interface on top of Reva `master` does not pass all the tests, we're not executing those tests. In a separate PR we will integrate such tests on the CI, with a custom GitHub runner similar to the Reva repo.