### PR TITLE
Send reva token to CodiMD

### DIFF
--- a/src/bridge/__init__.py
+++ b/src/bridge/__init__.py
@@ -135,7 +135,7 @@ def _gendocid(wopisrc):
 # The Bridge endpoints start here
 #############################################################################################################
 
-def appopen(wopisrc, acctok, appname, viewmode):
+def appopen(wopisrc, acctok, appname, viewmode, revatok=None):
     '''Open a doc by contacting the provided WOPISrc with the given access_token.
     Returns a (app-url, params{}) pair if successful, raises a FailedOpen exception otherwise'''
     wopisrc = urlparse.unquote_plus(wopisrc)
@@ -206,7 +206,7 @@ def appopen(wopisrc, acctok, appname, viewmode):
             wopilock = app.loadfromstorage(filemd, wopisrc, acctok, None)
 
         redirurl = app.getredirecturl(viewmode, wopisrc, acctok, wopilock['doc'][1:], filemd['BaseFileName'],
-                                      filemd['UserFriendlyName'])
+                                      filemd['UserFriendlyName'], revatok)
     except app.AppFailure as e:
         # this can be raised by loadfromstorage or getredirecturl
         usermsg = str(e) if str(e) else 'Unable to load the app, please try again later or contact support'

--- a/src/bridge/codimd.py
+++ b/src/bridge/codimd.py
@@ -53,7 +53,7 @@ def init(_appurl, _appinturl, _apikey):
         raise AppFailure
 
 
-def getredirecturl(viewmode, wopisrc, acctok, docid, filename, displayname):
+def getredirecturl(viewmode, wopisrc, acctok, docid, filename, displayname, revatok=None):
     '''Return a valid URL to the app for the given WOPI context'''
     if viewmode in (utils.ViewMode.READ_WRITE, utils.ViewMode.PREVIEW):
         mode = 'view' if viewmode == utils.ViewMode.PREVIEW else 'both'
@@ -63,6 +63,8 @@ def getredirecturl(viewmode, wopisrc, acctok, docid, filename, displayname):
             'disableEmbedding': ('%s' % (os.path.splitext(filename)[1] != '.zmd')).lower(),
             'displayName': displayname,
         }
+        if revatok:
+            params['revaToken'] = revatok
         return f'{appexturl}/{docid}?{mode}&{urlparse.urlencode(params)}'
 
     # read-only mode: first check if we have a CodiMD redirection

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -354,7 +354,8 @@ def iopOpenInApp():
     res = {}
     if bridge.issupported(appname):
         try:
-            res['app-url'], res['form-parameters'] = bridge.appopen(utils.generateWopiSrc(inode), acctok, appname, viewmode)
+            res['app-url'], res['form-parameters'] = bridge.appopen(utils.generateWopiSrc(inode), acctok, appname, viewmode,
+                                                                    usertoken)
         except bridge.FailedOpen as foe:
             return foe.msg, foe.statuscode
     else:


### PR DESCRIPTION
This PR adds the reva token to the data sent to the CodiMD client. This is temporary while another way to upload files is found, as discussed.