### PR TITLE
Added configuration flag to enable the business flow

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -71,12 +71,15 @@ def checkFileInfo(fileid, acctok):
            and srv.config.get('general', 'downloadurl', fallback=None):
             fmd['DownloadUrl'] = fmd['FileUrl'] = '%s?access_token=%s' % \
                 (srv.config.get('general', 'downloadurl'), flask.request.args['access_token'])
+        if srv.config.get('general', 'businessflow', fallback='False').upper() == 'TRUE':
+            # enable the check for real users, not for public links
+            fmd['LicenseCheckForEditIsEnabled'] = not fmd['IsAnonymousUser']
         fmd['BreadcrumbBrandName'] = srv.config.get('general', 'brandingname', fallback=None)
         fmd['BreadcrumbBrandUrl'] = srv.config.get('general', 'brandingurl', fallback=None)
         fmd['OwnerId'] = statInfo['ownerid']
         fmd['UserId'] = acctok['wopiuser']     # typically same as OwnerId; different when accessing shared documents
         fmd['Size'] = statInfo['size']
-        # note that in ownCloud the version is generated as: `'V' + etag + checksum`
+        # note that in ownCloud 10 the version is generated as: `'V' + etag + checksum`
         fmd['Version'] = 'v%s' % statInfo['etag']
         fmd['SupportsExtendedLockLength'] = fmd['SupportsGetLock'] = True
         fmd['SupportsUpdate'] = fmd['UserCanWrite'] = fmd['SupportsLocks'] = \

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -354,6 +354,9 @@ def iopOpenInApp():
         res['app-url'] = appurl if vm == utils.ViewMode.READ_WRITE else appviewurl
         res['app-url'] += '%sWOPISrc=%s' % ('&' if '?' in res['app-url'] else '?',
                                             utils.generateWopiSrc(inode, appname == Wopi.proxiedappname))
+        if Wopi.config.get('general', 'businessflow', fallback='False').upper() == 'TRUE':
+            # tells the app to enable the business flow if appropriate
+            res['app-url'] += '&IsLicensedUser=1'
         res['form-parameters'] = {'access_token': acctok}
 
     Wopi.log.info('msg="iopOpenInApp: redirecting client" appurl="%s"' % res['app-url'])

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -8,10 +8,14 @@
 [general]
 # Storage access layer to be loaded in order to operate this WOPI server
 # Supported values: local, xroot, cs3.
-#storagetype = xroot
+#storagetype =
 
 # Port where to listen for WOPI requests
 port = 8880
+
+# The internal server engine to use (defaults to flask).
+# Set to waitress for production installations.
+#internalserver = flask
 
 # Logging level. Debug enables the Flask debug mode as well.
 # Valid values are: Debug, Info, Warning, Error.
@@ -65,10 +69,6 @@ loghandler = file
 # a 'Edit in Desktop client' action on Windows-based clients
 #webdavurl = https://your-efss-server.org/webdav
 
-# The internal server engine to use (defaults to flask).
-# Set to waitress for production installations.
-#internalserver = flask
-
 # List of file extensions deemed incompatible with LibreOffice:
 # interoperable locking will be disabled for such files
 nonofficetypes = .md .zmd .txt
@@ -121,6 +121,10 @@ wopilockexpiration = 1800
 #wopiproxy = https://external-wopi-proxy.com
 #wopiproxysecretfile = /path/to/your/shared-key-file
 #proxiedappname = Name of your proxied app
+
+# A flag to enable the business flow with Microsoft Office as detailed in:
+# https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/business
+#businessflow = False
 
 ### The following options are deprecated and not to be used with Reva
 


### PR DESCRIPTION
This is actually a variant that supersedes https://github.com/cs3org/wopiserver/pull/102

The goal is to make the business flow dependent on the config flag only, not on whether the app is proxied or not, and to leave it out on public shares.

(And I gave up in hiding the technical details from the main `wopiserver.py` class)