### PR TITLE
Implemented forced eviction of locks

### DIFF
--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -73,7 +73,7 @@ def retrieverevalock(rawlock):
     '''Restores the JSON payload from a base64-encoded Reva lock'''
     try:
         return json.loads(urlsafe_b64decode(rawlock + '==').decode())
-    except (B64Error, json.JSONDecodeError) as e:
+    except (B64Error, json.JSONDecodeError, UnicodeDecodeError) as e:
         raise IOError("Unable to parse existing lock: " + str(e))
 
 

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -262,7 +262,8 @@ def setLock(fileid, reqheaders, acctok):
             if not retrievedLock:
                 retrievedLock, lockHolder = utils.retrieveWopiLock(fileid, op, lock, acctok)
             # validate against either the given lock (RefreshLock case) or the given old lock (UnlockAndRelock case)
-            if retrievedLock and not utils.compareWopiLocks(retrievedLock, (oldLock if oldLock else lock)):
+            if not retrievedLock or not utils.compareWopiLocks(retrievedLock, (oldLock if oldLock else lock)):
+                # in the context of the EXCL_ERROR case, retrievedLock may be None only if the storage is holding a user lock
                 # lock mismatch, the WOPI client is supposed to acknowledge the existing lock to start a collab session,
                 # or deny access to the file in edit mode otherwise
                 evicted = False

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -277,13 +277,13 @@ def setLock(fileid, reqheaders, acctok):
                 else:
                     return utils.makeConflictResponse(op, acctok['userid'], retrievedLock, lock, oldLock, fn,
                                                       'The file is locked by %s' %
-                                                      (lockHolder if lockHolder != 'wopi' else 'another online editor'),   # TODO cleanup 'wopi' case
+                                                      (lockHolder if lockHolder else 'another editor'),
                                                       savetime=savetime)
 
             # else it's our own lock, refresh it (rechecking the oldLock if necessary, for atomicity) and return
             try:
                 st.refreshlock(acctok['endpoint'], fn, acctok['userid'], acctok['appname'],
-                               utils.encodeLock(lock), utils.encodeLock(oldLock) if oldLock else None)
+                               utils.encodeLock(lock), utils.encodeLock(oldLock))
                 return utils.makeLockSuccessResponse(op, acctok, lock, 'v%s' % statInfo['etag'])
             except IOError as rle:
                 # this is unexpected now

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -236,10 +236,10 @@ def generateAccessToken(userid, fileid, viewmode, user, folderurl, endpoint, app
         tokmd['forcelock'] = '1'
     acctok = jwt.encode(tokmd, srv.wopisecret, algorithm='HS256')
     log.info('msg="Access token generated" userid="%s" wopiuser="%s" mode="%s" endpoint="%s" filename="%s" inode="%s" '
-             'mtime="%s" folderurl="%s" appname="%s" expiration="%d" forcelock="%s" token="%s"' %
+             'mtime="%s" folderurl="%s" appname="%s" %s expiration="%d" token="%s"' %
              (userid[-20:], wopiuser if wopiuser != userid else username, viewmode, endpoint,
               statinfo['filepath'], statinfo['inode'], statinfo['mtime'],
-              folderurl, appname, exptime, '1' if forcelock else '0', acctok[-20:]))
+              folderurl, appname, 'forcelock="True"' if forcelock else '', exptime, acctok[-20:]))
     return statinfo['inode'], acctok, viewmode
 
 
@@ -373,7 +373,7 @@ def checkAndEvictLock(user, appname, retrievedlock, lock, endpoint, filename, sa
         # file is being edited, don't evict existing lock
         log.warning('msg="File is actively edited, force-unlock prevented" lockop="Lock" user="%s" '
                     'filename="%s" fileage="%1.1f" token="%s" sessionId="%s"' %
-                    (user, filename, (time.time() - int(savetime)), flask.request.args['access_token'][-20:], session))
+                    (user, filename, (time.time() - savetime), flask.request.args['access_token'][-20:], session))
         return False
     # ok, remove current lock and set new one
     try:

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -90,6 +90,13 @@ wopilockexpiration = 1800
 # on-premise setups.
 #wopilockstrictcheck = False
 
+# Enable the ability to force-unlock sessions to overcome issues with Microsoft Office:
+# if a session (access token) includes the option to override a previous lock, and the
+# corresponding file was saved more than the given evictlocktime seconds before the request
+# for lock, the previous lock is force-unlocked in order to grant a lock to the new
+# session. By default this behavior is disabled.
+#evictlocktime =
+
 # Enable support of rename operations from WOPI apps. This is currently
 # disabled by default because the implementation is not complete,
 # and it is to be enabled for testing purposes only for the time being.


### PR DESCRIPTION
This PR introduces a feature to compensate an issue with the Microsoft Office cloud. It should hopefully be reverted once the issue is fixed with MS support.

The issue concerns a mishandling of collaborative sessions: it may happen that a new user trying to join an editing session is prevented from doing so because the existing session appears to be "forgotten" by the Microsoft cloud, whilst it is continuously being refreshed (therefore holding a valid WOPI lock). Typically this is the case when the existing session is not actively used, that is there has been no recent `PutFile` operation.

Here we introduce a configuration parameter `evictlocktime` and an `evictlock` additional query parameter on `/wopi/iop/openinapp`: if `evictlock=1` on the open call AND the file was saved more than `evictlocktime` seconds ago, then the existing and valid lock is evicted in favour of the new one. The net result is that the new user is allowed to edit the document, and the previous (presumably idle) user will get a "Session expired" message, requiring to reload. By default the `evictlocktime` value is `-1`, meaning that the feature is disabled.