### PR TITLE
CI: build an additional `arm64` docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,3 +20,17 @@ jobs:
       tags: ${{ matrix.tags }}
       build-args: VERSION=${{ github.ref_name }}
       push: true
+  release-arm64:
+    strategy:
+      matrix:
+        include:
+        - tags: ${{ vars.DOCKERHUB_ORGANIZATION }}/wopiserver:${{ github.ref_name }}-arm64
+          file: wopiserver-arm64.Dockerfile
+    uses: cs3org/reva/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      file: ${{ matrix.file }}
+      tags: ${{ matrix.tags }}
+      build-args: VERSION=${{ github.ref_name }}
+      push: true
+      platforms: linux/arm64

--- a/wopiserver-arm64.Dockerfile
+++ b/wopiserver-arm64.Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile for WOPI Server
+#
+# Build: WOPI_DOCKER_TYPE=-arm64 docker-compose -f wopiserver.yaml build --build-arg VERSION=`git describe | sed 's/^v//'` wopiserver
+# Run: docker-compose -f wopiserver.yaml up -d
+
+FROM python:3.10-slim-buster
+
+ARG VERSION=latest
+
+LABEL maintainer="cernbox-admins@cern.ch" \
+  org.opencontainers.image.title="The ScienceMesh IOP WOPI server" \
+  org.opencontainers.image.version="$VERSION"
+
+# prerequisites: we explicitly install g++ as it is required by grpcio but missing from its dependencies
+WORKDIR /app
+COPY requirements.txt .
+RUN apt -y install g++ && \
+    pip3 install --upgrade pip setuptools && \
+    pip3 install --no-cache-dir --upgrade -r requirements.txt
+
+# install software
+RUN mkdir -p /app/core /app/bridge /test /etc/wopi /var/log/wopi /var/wopi_local_storage
+COPY ./src/* ./tools/* /app/
+COPY ./src/core/* /app/core/
+COPY ./src/bridge/* /app/bridge/
+RUN sed -i "s/WOPISERVERVERSION = 'git'/WOPISERVERVERSION = '$VERSION'/" /app/wopiserver.py && \
+    grep 'WOPISERVERVERSION =' /app/wopiserver.py
+COPY wopiserver.conf /etc/wopi/wopiserver.defaults.conf
+COPY test/*py test/*conf /test/
+
+# add basic custom configuration; need to contextualize
+COPY ./docker/etc/*secret  ./docker/etc/wopiserver.conf /etc/wopi/
+
+ENTRYPOINT ["/app/wopiserver.py"]


### PR DESCRIPTION
Resolves https://github.com/cs3org/wopiserver/issues/109.

I've never used GitHub workflows before, so I'm not 100% sure this will work as expected.

Also, I created a separate `Dockerfile` for `arm64` as I had to switch from `python:3.11-alpine` to `python:3.10-slim-buster` base image. This is because it was failing to building on `alpine` even with the changes mentioned on https://github.com/grpc/grpc/issues/24722, and grpcio failed to build on `python-3.11` even on `slim-buster`.