### PR TITLE
Added config flag to disable detection of external changes

### DIFF
--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -106,8 +106,15 @@ wopilockexpiration = 1800
 # compatible with Office for Desktop applications are detected, assuming that the
 # underlying storage can be mounted as a remote filesystem: in this case, WOPI GetLock
 # and SetLock operations return such locks and prevent online apps from entering edit mode.
-# This feature can be disabled in order to operate a pure WOPI server for online apps.
+# This feature can be disabled, to operate a WOPI server with full control on the storage.
 #detectexternallocks = True
+
+# Detection of external modifications to locked files. By default, on PutFile operations
+# the system checks against a previously set extended attribute, and if missing or older
+# than the current file's mtime, PutFile is failed. This allows to operate on shared
+# storage systems that do not honour WOPI locks. Similarly to the above, this
+# feature can be disabled for storages where WOPI locking is fully honoured.
+#detectexternalmodifications = True
 
 # Location of the user's personal space, used as a fall back location when storing
 # PutRelative targets or webconflict files. Normally, such files are stored in the same


### PR DESCRIPTION
This feature allows to run the wopiserver in a less "conservative" mode as detailed in the `wopiserver.conf` comments.

The `lastmodificationtime` xattr is still stored in all cases as it is actually used for a particular lock check implemented for CodiMD. But the validation on `PutFile` is skipped when the detection flag is set to false.