### PR TITLE
Added health check of all storages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 grpcio>=1.47.0
 grpcio-tools>=1.47.0
+grpcio-health-checking
 cygrpc
 flask
 pyOpenSSL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 grpcio>=1.47.0
 grpcio-tools>=1.47.0
-grpcio-health-checking
 cygrpc
 flask
 pyOpenSSL

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -65,6 +65,21 @@ def init(inconfig, inlog):
             raise IOError('Not a directory')
     except IOError as e:
         raise IOError(f'Could not stat storagehomepath folder {homepath}: {e}')
+    # all right but inform the user
+    log.warning('msg="Use this local storage interface for test/development purposes only, not for production"')
+
+def healthcheck():
+    '''Probes the storage and returns a status message. For local storage, we just stat the root'''
+    try:
+        stat(None, '/', None)
+    except IOError as e:
+        if str(e) == 'Is a directory':
+            # that's expected
+            log.info('msg="Executed health check against storage root"')
+            return 'OK'
+        # any other error is a failure
+        log.error('msg="Health check failed against storage root" error="%s"' % e)
+        return str(e)
 
 
 def getuseridfromcreds(_token, _wopiuser):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -72,11 +72,12 @@ def healthcheck():
     '''Probes the storage and returns a status message. For local storage, we just stat the root'''
     try:
         stat(None, '/', None)
+        return 'Warning'   # to please CodeQL but never reached
     except IOError as e:
         if str(e) == 'Is a directory':
-            # that's expected
+            # that's expected, yet we return warning as this is a test/dev storage interface
             log.info('msg="Executed health check against storage root"')
-            return 'OK'
+            return 'Warning'
         # any other error is a failure
         log.error('msg="Health check failed against storage root" error="%s"' % e)
         return str(e)

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -159,6 +159,20 @@ def _getfilepath(filepath, encodeamp=False):
     return homepath + (filepath if not encodeamp else filepath.replace('&', '#AND#'))
 
 
+def healthcheck():
+    '''Probes the storage and returns a status message. For xrootd storage, we stat the default endpoint'''
+    try:
+        stat('default', '/', '0:0')
+    except IOError as e:
+        if str(e) == 'Is a directory':
+            # that's expected
+            log.info('msg="Executed health check against default endpoint"')
+            return 'OK'
+        # any other error is a failure
+        log.error('msg="Health check failed against default endpoint" error="%s"' % e)
+        return str(e)
+
+
 def getuseridfromcreds(_token, wopiuser):
     '''Maps a Reva token and wopiuser to the credentials to be used to access the storage.
     For the xrootd case, we have to resolve the username to uid:gid and return

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -163,6 +163,7 @@ def healthcheck():
     '''Probes the storage and returns a status message. For xrootd storage, we stat the default endpoint'''
     try:
         stat('default', '/', '0:0')
+        return 'OK'   # to please CodeQL but never reached
     except IOError as e:
         if str(e) == 'Is a directory':
             # that's expected

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -241,10 +241,13 @@ def index():
       The service includes support for non-WOPI-native apps through a bridge extension.<br>
       To use this service, please log in to your EFSS Storage and click on a supported document.</div>
       <div style="position: absolute; bottom: 10px; left: 10px; width: 99%%;"><hr>
-      <i>ScienceMesh WOPI Server %s at %s. Powered by Flask %s for Python %s</i>.
+      <i>ScienceMesh WOPI Server %s at %s. Powered by Flask %s for Python %s.
+         Storage type: <span style="font-family:monospace">%s</span>.
+         Health check: <span style="font-family:monospace">%s</span>.</i>
       </body>
       </html>
-      """ % (WOPISERVERVERSION, socket.getfqdn(), flask.__version__, python_version()))
+      """ % (WOPISERVERVERSION, socket.getfqdn(), flask.__version__, python_version(),
+             Wopi.config.get('general', 'storagetype'), storage.healthcheck()))
     resp.headers['X-Frame-Options'] = 'sameorigin'
     resp.headers['X-XSS-Protection'] = '1; mode=block'
     return resp


### PR DESCRIPTION
Inspired by recent deployment attempts, this PR introduces a health check that is executed on the "index" page of the server. The goal is to have a quick feedback whether the service is properly configured to talk to the underlying storage.