### PR TITLE
Implemented workaround for mismatched locks in PutFile

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -575,14 +575,15 @@ def putFile(fileid, acctok):
     if 'X-WOPI-Lock' not in flask.request.headers:
         # no lock given: assume we are in creation mode (cf. editnew WOPI action)
         return _createNewFile(fileid, acctok)
-    # otherwise, check that the caller holds the current lock on the file: the check is in non-strict mode
-    # as we have observed cases of lock mismatch (but matching sessionId) that lead to incorrect save failures
+    # otherwise, check that the caller holds the current lock on the file: the check can be executed in non-strict mode,
+    # which would help with observed cases of lock mismatch (but matching sessionId) that led to incorrect save failures
     lock = flask.request.headers['X-WOPI-Lock']
     retrievedLock, lockHolder = utils.retrieveWopiLock(fileid, 'PUTFILE', lock, acctok)
     if retrievedLock is None:
         return utils.makeConflictResponse('PUTFILE', acctok['userid'], retrievedLock, lock, 'NA',
                                           acctok['filename'], 'Cannot overwrite unlocked file')
-    if not utils.compareWopiLocks(retrievedLock, lock, strict=False):
+    strictcheck = srv.config.get('general', 'wopilockstrictcheckonput', fallback='True').upper() == 'TRUE'
+    if not utils.compareWopiLocks(retrievedLock, lock, strict=strictcheck):
         log.warning('msg="Forcing conflict based on mismatched lock" holder="%s" user="%s" filename="%s" token="%s"' %
                     (lockHolder, acctok['userid'][-20:], acctok['filename'], flask.request.args['access_token'][-20:]))
         return utils.storeAfterConflict(acctok, retrievedLock, lock, 'Cannot overwrite file locked by %s' %

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -352,13 +352,13 @@ def compareWopiLocks(lock1, lock2, strict=True):
         try:
             l2 = json.loads(lock2)
             if 'S' in l1 and 'S' in l2:
-                log.debug('msg="compareLocks" lock1="%s" lock2="%s" strict="False" result="%r"' %
+                log.warn('msg="compareLocks" lock1="%s" lock2="%s" strict="False" result="%r"' %
                           (lock1, lock2, l1['S'] == l2['S']))
                 return l1['S'] == l2['S']         # used by Word
         except (TypeError, ValueError):
             # lock2 is not a JSON dictionary
             if 'S' in l1:
-                log.debug('msg="compareLocks" lock1="%s" lock2="%s" strict="False" result="%r"' %
+                log.warn('msg="compareLocks" lock1="%s" lock2="%s" strict="False" result="%r"' %
                           (lock1, lock2, l1['S'] == lock2))
                 return l1['S'] == lock2                    # also used by Word
     except (TypeError, ValueError):

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -334,7 +334,7 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefn=None):
     return lockcontent['lock_id'], lockcontent['app_name']
 
 
-def compareWopiLocks(lock1, lock2):
+def compareWopiLocks(lock1, lock2, strict=True):
     '''Compares two locks and returns True if they represent the same WOPI lock.
     Officially, the comparison must be based on the locks' string representations. But because of
     a bug in early versions of Word Online, the internal format of the WOPI locks may be looked at,
@@ -342,7 +342,7 @@ def compareWopiLocks(lock1, lock2):
     if lock1 == lock2:
         log.debug(f'msg="compareLocks" lock1="{lock1}" lock2="{lock2}" result="True"')
         return True
-    if srv.config.get('general', 'wopilockstrictcheck', fallback='True').upper() == 'TRUE':
+    if srv.config.get('general', 'wopilockstrictcheck', fallback='True').upper() == 'TRUE' and strict:
         log.debug(f'msg="compareLocks" lock1="{lock1}" lock2="{lock2}" strict="True" result="False"')
         return False
 

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -87,11 +87,12 @@ tokenvalidity = 86400
 # therefore the default value SHALL NOT be changed in production environments.
 wopilockexpiration = 1800
 
-# WOPI lock strict check: if True (default), WOPI locks will be compared according to specs,
+# WOPI lock strict checks: if True (default), WOPI locks will be compared according to specs,
 # that is their representation must match. False allows for a more relaxed comparison,
 # which compensates incorrect lock requests from Microsoft Office Online 2016-2018
-# on-premise setups.
+# on-premise setups. The wopilockstrictcheckonput flag applies for PutFile operations.
 #wopilockstrictcheck = True
+#wopilockstrictcheckonput = True
 
 # Enable support of rename operations from WOPI apps. This is currently
 # disabled by default because the implementation is not complete,


### PR DESCRIPTION
This workaround should help with cases where `PutFile` is invoked with a mismatched lock, but with the right session UUID.

Not to be merged until consequences are clear, as the introduced behavior does not respect the WOPI specifications.