### PR TITLE
Implemented support for X-Trace-Id header

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -451,7 +451,8 @@ def putRelative(fileid, reqheaders, acctok):
     inode, newacctok, _ = utils.generateAccessToken(acctok['userid'], targetName, utils.ViewMode.READ_WRITE,
                                                     (acctok['username'], acctok['wopiuser'], utils.UserType(acctok['usertype'])),
                                                     acctok['folderurl'], acctok['endpoint'],
-                                                    (acctok['appname'], acctok['appediturl'], acctok['appviewurl']))
+                                                    (acctok['appname'], acctok['appediturl'], acctok['appviewurl']),
+                                                    acctok.get('trace', 'N/A'))
     # prepare and send the response as JSON
     _, newfileid = common.decodeinode(inode)
     mdforhosturls = {


### PR DESCRIPTION
Fixes #64. The trace is logged once for each request as part of the `client context`.