### PR TITLE
Fixed SaveAs logic for non-authenticated users

### DIFF
--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -147,8 +147,7 @@ class Wopi:
                     cls.log.error('msg="Failed to open the provided certificate or key to start in https mode"')
                     raise
             cls.wopiurl = cls.config.get('general', 'wopiurl')
-            cls.homepath = cls.config.get('general', 'homepath',
-                                          fallback=cls.config.get('general', 'conflictpath', fallback='/home/username'))
+            cls.homepath = cls.config.get('general', 'homepath', fallback='/home/username')
             cls.recoverypath = cls.config.get('io', 'recoverypath', fallback='/var/spool/wopirecovery')
             try:
                 os.makedirs(cls.recoverypath)


### PR DESCRIPTION
This patch fixes the logic to allow SaveAs operations.

As the wopiserver does not know if a public share (where a file was opened) can be written to, that is it's a shared folder, the SaveAs operation is now offered _only_ if the user is authenticated, otherwise only a "Download a copy" is possible, unless the `VIEW_ONLY` mode was used. The previous optimistic approach can lead to files successfully written (on behalf of the owner) to the shared folder, but inaccessible by the user, that is asked to login after the SaveAs operation.

For authenticated users, the behavior remains unchanged: if the shared folder is writable, a SaveAs operation will write a file in the same folder. Otherwise, the file is stored in the user's home folder, identified via the `homepath` configuration variable (the `conflictpath` deprecated parameter is now gone). If the backend does not allow to address absolute paths, then the SaveAs operation will be failed in the latter case.