### PR TITLE
Use Flask stream when writing data to storage

### DIFF
--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -475,10 +475,10 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
         log.warning(f'msg="Access denied uploading file to Reva" reason="{putres.reason}"')
         raise IOError(common.ACCESS_ERROR)
     if putres.status_code != http.client.OK:
-        if size == 0: # 0-byte file uploads may have been finalized after InitiateFileUploadRequest, let's assume it's OK
+        if size == 0:  # 0-byte file uploads may have been finalized after InitiateFileUploadRequest, let's assume it's OK
             # TODO this use-case is to be reimplemented with a call to `TouchFile`.
             log.info('msg="0-byte file written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %
-                (filepath, (tend - tstart) * 1000, islock))
+                     (filepath, (tend - tstart) * 1000, islock))
             return
 
         log.error('msg="Error uploading file to Reva" code="%d" reason="%s"' % (putres.status_code, putres.reason))

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -427,7 +427,7 @@ def readfile(endpoint, filepath, userid, lockid):
             yield chunk
 
 
-def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
+def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     '''Write a file using the given userid as access token. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
     The islock flag is currently not supported. The backend should at least support
@@ -441,9 +441,10 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
         _, lockid = lockmd    # TODO we are not validating the holder on write, only the lock_id
     else:
         lockid = None
-    if isinstance(content, str):
+    if size == 0:
         content = bytes(content, 'UTF-8')
-    size = str(len(content))
+        size = len(content)
+    size = str(size)
     reference = _getcs3reference(endpoint, filepath)
     req = cs3sp.InitiateFileUploadRequest(ref=reference, lock_id=lockid, opaque=types.Opaque(
         map={"Upload-Length": types.OpaqueEntry(decoder="plain", value=str.encode(size))}))

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -442,7 +442,8 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     else:
         lockid = None
     if size == 0:
-        content = bytes(content, 'UTF-8')
+        if isinstance(content, str):
+            content = bytes(content, 'UTF-8')
         size = len(content)
     reference = _getcs3reference(endpoint, filepath)
     req = cs3sp.InitiateFileUploadRequest(ref=reference, lock_id=lockid, opaque=types.Opaque(

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -441,7 +441,7 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
         _, lockid = lockmd    # TODO we are not validating the holder on write, only the lock_id
     else:
         lockid = None
-    if size == 0:
+    if size == -1:
         if isinstance(content, str):
             content = bytes(content, 'UTF-8')
         size = len(content)

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -464,7 +464,7 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
         protocol = [p for p in res.protocols if p.protocol in ["simple", "spaces"]][0]
         headers = {
             'x-access-token': userid,
-            'Upload-Length': size,
+            'Upload-Length': str(size),
             'x-reva-transfer': protocol.token        # needed if the uploads pass through the data gateway in reva
         }
         putres = requests.put(url=protocol.upload_endpoint, data=content, headers=headers, verify=ctx['ssl_verify'], timeout=10)

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -244,13 +244,13 @@ def readfile(_endpoint, filepath, _userid, _lockid):
         yield IOError(e)
 
 
-def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
+def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     '''Write a file via xroot on behalf of the given userid. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
     With islock=True, the file is opened with O_CREAT|O_EXCL.'''
-    if isinstance(content, str):
+    if size == 0:
         content = bytes(content, 'UTF-8')
-    size = len(content)
+        size = len(content)
     if lockmd:
         _validatelock(filepath, getlock(endpoint, filepath, userid), lockmd, 'writefile', log)
     elif getlock(endpoint, filepath, userid):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -249,7 +249,8 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     and any pre-existing file is deleted (or moved to the previous version if supported).
     With islock=True, the file is opened with O_CREAT|O_EXCL.'''
     if size == 0:
-        content = bytes(content, 'UTF-8')
+        if isinstance(content, str):
+            content = bytes(content, 'UTF-8')
         size = len(content)
     if lockmd:
         _validatelock(filepath, getlock(endpoint, filepath, userid), lockmd, 'writefile', log)

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -248,7 +248,7 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     '''Write a file via xroot on behalf of the given userid. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
     With islock=True, the file is opened with O_CREAT|O_EXCL.'''
-    if size == 0:
+    if size == -1:
         if isinstance(content, str):
             content = bytes(content, 'UTF-8')
         size = len(content)

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -222,7 +222,7 @@ def setLock(fileid, reqheaders, acctok):
             lockcontent = ',Collaborative Online Editor,%s,%s,WOPIServer;' % \
                           (srv.wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())))
             st.writefile(acctok['endpoint'], utils.getLibreOfficeLockName(fn), acctok['userid'],
-                         lockcontent, None, islock=True)
+                         lockcontent, 0, None, islock=True)
         except IOError as e:
             if common.EXCL_ERROR in str(e):
                 # retrieve the LibreOffice-compatible lock just found

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -222,7 +222,7 @@ def setLock(fileid, reqheaders, acctok):
             lockcontent = ',Collaborative Online Editor,%s,%s,WOPIServer;' % \
                           (srv.wopiurl, time.strftime('%d.%m.%Y %H:%M', time.localtime(time.time())))
             st.writefile(acctok['endpoint'], utils.getLibreOfficeLockName(fn), acctok['userid'],
-                         lockcontent, 0, None, islock=True)
+                         lockcontent, -1, None, islock=True)
         except IOError as e:
             if common.EXCL_ERROR in str(e):
                 # retrieve the LibreOffice-compatible lock just found

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -101,9 +101,9 @@ def checkFileInfo(fileid, acctok):
         # Instead, regular (authenticated) users are offered a SaveAs (unless in view-only mode), where the operation
         # is executed to the user's home if no access is given to the same folder where the file is.
         fmd['UserCanNotWriteRelative'] = acctok['viewmode'] == utils.ViewMode.VIEW_ONLY or \
-                                         acctok['usertype'] != utils.UserType.REGULAR
+            acctok['usertype'] != utils.UserType.REGULAR
         fmd['SupportsRename'] = fmd['UserCanRename'] = enablerename and \
-                                                       acctok['viewmode'] in (utils.ViewMode.READ_WRITE, utils.ViewMode.PREVIEW)
+            acctok['viewmode'] in (utils.ViewMode.READ_WRITE, utils.ViewMode.PREVIEW)
         fmd['SupportsUserInfo'] = True
         uinfo = st.getxattr(acctok['endpoint'], acctok['filename'], acctok['userid'],
                             utils.USERINFOKEY + '.' + acctok['wopiuser'].split('!')[0])

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -447,7 +447,8 @@ def storeWopiFile(acctok, retrievedlock, xakey, targetname=''):
 
     writeerror = None
     try:
-        st.writefile(acctok['endpoint'], targetname, acctok['userid'], flask.request.get_data(),
+        st.writefile(acctok['endpoint'], targetname, acctok['userid'],
+                     flask.request.stream, flask.request.content_length,
                      (acctok['appname'], encodeLock(retrievedlock)))
     except IOError as e:
         if str(e) == common.ACCESS_ERROR:

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -439,7 +439,7 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
          and any pre-existing file is deleted (or moved to the previous version if supported).
          With islock=True, the write explicitly disables versioning, and the file is opened with
          O_CREAT|O_EXCL, preventing race conditions.'''
-    if size == 0:
+    if size == -1:
         size = len(content)
     log.debug('msg="Invoking writeFile" filepath="%s" userid="%s" size="%d" islock="%s"' % (filepath, userid, size, islock))
     if islock:

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -434,12 +434,13 @@ def readfile(endpoint, filepath, userid, _lockid):
                 yield chunk
 
 
-def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
+def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
     '''Write a file via xroot on behalf of the given userid. The entire content is written
          and any pre-existing file is deleted (or moved to the previous version if supported).
          With islock=True, the write explicitly disables versioning, and the file is opened with
          O_CREAT|O_EXCL, preventing race conditions.'''
-    size = len(content)
+    if size == 0:
+        size = len(content)
     log.debug('msg="Invoking writeFile" filepath="%s" userid="%s" size="%d" islock="%s"' % (filepath, userid, size, islock))
     if islock:
         # this is required to trigger the O_EXCL behavior on EOS when creating lock files

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -196,7 +196,8 @@ class TestStorage(unittest.TestCase):
         except IOError:
             pass
         t = Thread(target=self.storage.writefile,
-                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, -1, None], kwargs={'islock': True})
+                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, -1, None],
+                   kwargs={'islock': True})
         t.start()
         with self.assertRaises(IOError) as context:
             time.sleep(0.001)

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -86,7 +86,7 @@ class TestStorage(unittest.TestCase):
 
     def test_stat(self):
         '''Call stat() and assert the path matches'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/test.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.assertTrue('mtime' in statInfo, 'Missing mtime from stat output')
@@ -95,7 +95,7 @@ class TestStorage(unittest.TestCase):
 
     def test_statx_fileid(self):
         '''Call statx() and test if fileid-based stat is supported'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, -1, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid, versioninv=0)
         self.assertTrue('inode' in statInfo, 'Missing inode from statx output')
         self.assertTrue('filepath' in statInfo, 'Missing filepath from statx output')
@@ -107,11 +107,11 @@ class TestStorage(unittest.TestCase):
 
     def test_statx_invariant_fileid(self):
         '''Call statx() before and after updating a file, and assert the inode did not change'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, -1, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test&upd.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         inode = statInfo['inode']
-        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, -1, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test&upd.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.assertEqual(statInfo['inode'], inode, 'Fileid is not invariant to multiple write operations')
@@ -131,7 +131,7 @@ class TestStorage(unittest.TestCase):
 
     def test_readfile_bin(self):
         '''Writes a binary file and reads it back, validating that the content matches'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, -1, None)
         content = ''
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
@@ -142,7 +142,7 @@ class TestStorage(unittest.TestCase):
     def test_readfile_text(self):
         '''Writes a text file and reads it back, validating that the content matches'''
         content = 'bla\n'
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, -1, None)
         content = ''
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
@@ -153,7 +153,7 @@ class TestStorage(unittest.TestCase):
     def test_readfile_empty(self):
         '''Writes an empty file and reads it back, validating that the read does not fail'''
         content = ''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, -1, None)
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
             content += chunk.decode('utf-8')
@@ -168,7 +168,7 @@ class TestStorage(unittest.TestCase):
 
     def test_write_remove_specialchars(self):
         '''Test write and removal of a file with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.removefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
@@ -181,11 +181,11 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testoverwrite', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, 0, None, islock=True)
+        self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, -1, None, islock=True)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testoverwrite', self.userid)
         self.assertIsInstance(statInfo, dict)
         with self.assertRaises(IOError) as context:
-            self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, 0, None, islock=True)
+            self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, -1, None, islock=True)
         self.assertIn(EXCL_ERROR, str(context.exception))
         self.storage.removefile(self.endpoint, self.homepath + '/testoverwrite', self.userid)
 
@@ -196,11 +196,11 @@ class TestStorage(unittest.TestCase):
         except IOError:
             pass
         t = Thread(target=self.storage.writefile,
-                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, 0, None], kwargs={'islock': True})
+                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, -1, None], kwargs={'islock': True})
         t.start()
         with self.assertRaises(IOError) as context:
             time.sleep(0.001)
-            self.storage.writefile(self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, 0, None, islock=True)
+            self.storage.writefile(self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, -1, None, islock=True)
         self.assertIn(EXCL_ERROR, str(context.exception))
         t.join()
         self.storage.removefile(self.endpoint, self.homepath + '/testwriterace', self.userid)
@@ -211,7 +211,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlock', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlock', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlock', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testlock', self.userid, 'test app', 'testlock')
@@ -233,7 +233,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testrlock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testrlock', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testrlock', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testrlock', self.userid)
         self.assertIsInstance(statInfo, dict)
         with self.assertRaises(IOError) as context:
@@ -262,7 +262,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlockrace', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockrace', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockrace', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlockrace', self.userid)
         self.assertIsInstance(statInfo, dict)
         t = Thread(target=self.storage.setlock,
@@ -280,15 +280,15 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlockop', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlockop', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testlockop', self.userid, 'test app', 'testlock')
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, ('test app', 'testlock'))
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, -1, ('test app', 'testlock'))
         with self.assertRaises(IOError):
             # Note that different interfaces raise exceptions on either mismatching app xor mismatching lock payload,
             # this is why we test that both mismatch. Could be improved, though we specifically care about the lock paylaod.
-            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0,
+            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, -1,
                                    ('mismatch app', 'mismatchlock'))
         with self.assertRaises(IOError):
             # same as above
@@ -304,7 +304,7 @@ class TestStorage(unittest.TestCase):
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/testlockop', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile, lock shall be shared')
         with self.assertRaises(IOError):
-            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, None)
+            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, -1, None)
         self.storage.renamefile(self.endpoint, self.homepath + '/testlockop', self.homepath + '/testlockop_renamed',
                                 self.userid, ('test app', 'testlock'))
         self.storage.removefile(self.endpoint, self.homepath + '/testlockop_renamed', self.userid)
@@ -315,7 +315,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testelock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testelock', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testelock', self.userid, databuf, -1, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testelock', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testelock', self.userid, 'test app', 'testlock')
@@ -347,7 +347,7 @@ class TestStorage(unittest.TestCase):
 
     def test_xattr(self):
         '''Test all xattr methods with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, databuf, -1, None)
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123, None)
         self.storage.setlock(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'test app', 'xattrlock')
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123,
@@ -361,7 +361,7 @@ class TestStorage(unittest.TestCase):
 
     def test_rename_statx(self):
         '''Test renaming and statx of a file with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, -1, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid)
         pathref = statInfo['filepath'][:statInfo['filepath'].rfind('/')]
 

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -20,7 +20,7 @@ sys.path.append('src')         # for tests out of the git repo
 sys.path.append('/app')        # for tests within the Docker image
 from core.commoniface import EXCL_ERROR, ENOENT_MSG  # noqa: E402
 
-databuf = b'ebe5tresbsrdthbrdhvdtr'
+databuf = 'ebe5tresbsrdthbrdhvdtr'
 
 
 class TestStorage(unittest.TestCase):
@@ -86,7 +86,7 @@ class TestStorage(unittest.TestCase):
 
     def test_stat(self):
         '''Call stat() and assert the path matches'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/test.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.assertTrue('mtime' in statInfo, 'Missing mtime from stat output')
@@ -95,7 +95,7 @@ class TestStorage(unittest.TestCase):
 
     def test_statx_fileid(self):
         '''Call statx() and test if fileid-based stat is supported'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid, versioninv=0)
         self.assertTrue('inode' in statInfo, 'Missing inode from statx output')
         self.assertTrue('filepath' in statInfo, 'Missing filepath from statx output')
@@ -107,11 +107,11 @@ class TestStorage(unittest.TestCase):
 
     def test_statx_invariant_fileid(self):
         '''Call statx() before and after updating a file, and assert the inode did not change'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, 0, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test&upd.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         inode = statInfo['inode']
-        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&upd.txt', self.userid, databuf, 0, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test&upd.txt', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.assertEqual(statInfo['inode'], inode, 'Fileid is not invariant to multiple write operations')
@@ -131,18 +131,18 @@ class TestStorage(unittest.TestCase):
 
     def test_readfile_bin(self):
         '''Writes a binary file and reads it back, validating that the content matches'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
         content = ''
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
             content += chunk.decode('utf-8')
-        self.assertEqual(content, databuf.decode(), f'File test.txt should contain the string "{databuf.decode()}"')
+        self.assertEqual(content, databuf, f'File test.txt should contain the string "{databuf}"')
         self.storage.removefile(self.endpoint, self.homepath + '/test.txt', self.userid)
 
     def test_readfile_text(self):
         '''Writes a text file and reads it back, validating that the content matches'''
         content = 'bla\n'
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, 0, None)
         content = ''
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
@@ -153,7 +153,7 @@ class TestStorage(unittest.TestCase):
     def test_readfile_empty(self):
         '''Writes an empty file and reads it back, validating that the read does not fail'''
         content = ''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, content, 0, None)
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/test.txt', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile')
             content += chunk.decode('utf-8')
@@ -168,7 +168,7 @@ class TestStorage(unittest.TestCase):
 
     def test_write_remove_specialchars(self):
         '''Test write and removal of a file with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.removefile(self.endpoint, self.homepath + '/testwrite&rm', self.userid)
@@ -181,11 +181,11 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testoverwrite', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, None, islock=True)
+        self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, 0, None, islock=True)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testoverwrite', self.userid)
         self.assertIsInstance(statInfo, dict)
         with self.assertRaises(IOError) as context:
-            self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, None, islock=True)
+            self.storage.writefile(self.endpoint, self.homepath + '/testoverwrite', self.userid, databuf, 0, None, islock=True)
         self.assertIn(EXCL_ERROR, str(context.exception))
         self.storage.removefile(self.endpoint, self.homepath + '/testoverwrite', self.userid)
 
@@ -196,11 +196,11 @@ class TestStorage(unittest.TestCase):
         except IOError:
             pass
         t = Thread(target=self.storage.writefile,
-                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, None], kwargs={'islock': True})
+                   args=[self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, 0, None], kwargs={'islock': True})
         t.start()
         with self.assertRaises(IOError) as context:
             time.sleep(0.001)
-            self.storage.writefile(self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, None, islock=True)
+            self.storage.writefile(self.endpoint, self.homepath + '/testwriterace', self.userid, databuf, 0, None, islock=True)
         self.assertIn(EXCL_ERROR, str(context.exception))
         t.join()
         self.storage.removefile(self.endpoint, self.homepath + '/testwriterace', self.userid)
@@ -211,7 +211,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlock', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlock', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlock', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testlock', self.userid, 'test app', 'testlock')
@@ -233,7 +233,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testrlock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testrlock', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testrlock', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testrlock', self.userid)
         self.assertIsInstance(statInfo, dict)
         with self.assertRaises(IOError) as context:
@@ -262,7 +262,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlockrace', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockrace', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockrace', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlockrace', self.userid)
         self.assertIsInstance(statInfo, dict)
         t = Thread(target=self.storage.setlock,
@@ -280,15 +280,15 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testlockop', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testlockop', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testlockop', self.userid, 'test app', 'testlock')
-        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, ('test app', 'testlock'))
+        self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, ('test app', 'testlock'))
         with self.assertRaises(IOError):
             # Note that different interfaces raise exceptions on either mismatching app xor mismatching lock payload,
             # this is why we test that both mismatch. Could be improved, though we specifically care about the lock paylaod.
-            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf,
+            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0,
                                    ('mismatch app', 'mismatchlock'))
         with self.assertRaises(IOError):
             # same as above
@@ -304,7 +304,7 @@ class TestStorage(unittest.TestCase):
         for chunk in self.storage.readfile(self.endpoint, self.homepath + '/testlockop', self.userid, None):
             self.assertNotIsInstance(chunk, IOError, 'raised by storage.readfile, lock shall be shared')
         with self.assertRaises(IOError):
-            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, None)
+            self.storage.writefile(self.endpoint, self.homepath + '/testlockop', self.userid, databuf, 0, None)
         self.storage.renamefile(self.endpoint, self.homepath + '/testlockop', self.homepath + '/testlockop_renamed',
                                 self.userid, ('test app', 'testlock'))
         self.storage.removefile(self.endpoint, self.homepath + '/testlockop_renamed', self.userid)
@@ -315,7 +315,7 @@ class TestStorage(unittest.TestCase):
             self.storage.removefile(self.endpoint, self.homepath + '/testelock', self.userid)
         except IOError:
             pass
-        self.storage.writefile(self.endpoint, self.homepath + '/testelock', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/testelock', self.userid, databuf, 0, None)
         statInfo = self.storage.stat(self.endpoint, self.homepath + '/testelock', self.userid)
         self.assertIsInstance(statInfo, dict)
         self.storage.setlock(self.endpoint, self.homepath + '/testelock', self.userid, 'test app', 'testlock')
@@ -347,7 +347,7 @@ class TestStorage(unittest.TestCase):
 
     def test_xattr(self):
         '''Test all xattr methods with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, databuf, 0, None)
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123, None)
         self.storage.setlock(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'test app', 'xattrlock')
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123,
@@ -361,7 +361,7 @@ class TestStorage(unittest.TestCase):
 
     def test_rename_statx(self):
         '''Test renaming and statx of a file with special chars'''
-        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, None)
+        self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, 0, None)
         statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid)
         pathref = statInfo['filepath'][:statInfo['filepath'].rfind('/')]
 


### PR DESCRIPTION
Supersedes https://github.com/cs3org/wopiserver/pull/138.

We use the flask write stream to spare an in-memory buffer copy (the actual request is still processed in one go as it's a POST).

The `writefile()` signature was changed to accept either a `byte[]` buffer or a stream as content, and the size as an extra parameter (`-1` would mean that the function must compute it assuming content is a buffer).

To be tested for all interfaces:
- [x] xroot
- [x] cs3
- [x] local (CI will be sufficient)