### PR TITLE
0-byte uploads are completed after the InitiateFileUploads call already

### DIFF
--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -474,7 +474,8 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
         log.warning(f'msg="Access denied uploading file to Reva" reason="{putres.reason}"')
         raise IOError(common.ACCESS_ERROR)
     if putres.status_code != http.client.OK:
-        if len(content) == 0: # 0-byte file uploads are finalized after the InitiateFileUploadRequest request already
+        if len(content) == 0: # 0-byte file uploads may have been finalized after the InitiateFileUploadRequest request already, let's assume it's OK
+        # TODO this use-case is to be reimplemented with a call to `TouchFile`.
             log.info('msg="0-byte file written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %
                 (filepath, (tend - tstart) * 1000, islock))
             return

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -474,6 +474,11 @@ def writefile(endpoint, filepath, userid, content, lockmd, islock=False):
         log.warning(f'msg="Access denied uploading file to Reva" reason="{putres.reason}"')
         raise IOError(common.ACCESS_ERROR)
     if putres.status_code != http.client.OK:
+        if len(content) == 0: # 0-byte file uploads are finalized after the InitiateFileUploadRequest request already
+            log.info('msg="0-byte file written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %
+                (filepath, (tend - tstart) * 1000, islock))
+            return
+
         log.error('msg="Error uploading file to Reva" code="%d" reason="%s"' % (putres.status_code, putres.reason))
         raise IOError(putres.reason)
     log.info('msg="File written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %


### PR DESCRIPTION
This PR changes the wopiserver to treat 0-byte uploads as finished after the `InitiateFileUploadRequest` already to match the behavior of reva edge. I suppose this might break compatibility with reva master so it'll likely need some discussion.

@glpatcern In reva edge we [changed the behavior](https://github.com/cs3org/reva/commit/c90c0b03bec0cce84eb778a116e921077f632a71) for 0-byte uploads so that they are finalized as part of the `InitiateFileUploadRequest` request already. This is analogous to [what tusd does](https://github.com/tus/tusd/blob/main/pkg/handler/unrouted_handler.go#L415-L422) in the TUS POST requests and fixes a [bug with 0-byte TUS uploads](https://github.com/owncloud/ocis/issues/8003) where uploads were not finalized because reva doesn't use the TUS POST handler and subsequent PATCH requests, which would finalize the upload, are not sent in this case.

So, do you know if this actually causes a problem for reva master? Or would you consider changing the behavior in master as well?

/cc @micbar @butonic 