### PR TITLE
Fix "TypeError: BufferedWriter.write() takes no keyword arguments" error in localiface.py

### DIFF
--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -283,7 +283,8 @@ def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
                         chunk = content.read(chunksize)
                         if len(chunk) == 0:
                             break
-                        written += f.write(chunk, offset=o, size=len(chunk))
+                        f.seek(o)
+                        written += f.write(chunk)
                         o += len(chunk)
                 else:
                     written = f.write(content)


### PR DESCRIPTION
# Description

This PR is a fix for the following error:

File "/app/core/localiface.py", line 286, in writefile written += f.write(chunk, offset=o, size=len(chunk)) 
TypeError: BufferedWriter.write() takes no keyword arguments

that occurs when a file must be saved and the local storage type is used.

