### PR TITLE
Introduce the new cs3-python-client library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog for the WOPI server
 
+### Future - v11.0.0
+- Adopted the cs3 python client (#161), and optimized the logic
+  that deals with extended attributes
+- Ported xrootd docker image to Alma9 (#164)
+- Forced preview mode for non-regular (non-primary) accounts
+
 ### Fri May 24 2024 - v10.5.0
 - Added timeout settings for GRPC and HTTP connections (#149)
 - Fixed handing of trailing slashes (#151)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Contributors (oldest contributions first):
 - Vasco Guita (@vascoguita)
 - Thomas Mueller (@deepdiver1975)
 - Andre Duffeck (@aduffeck)
+- Rasmus Welander (@rawe0)
 
 Initial revision: December 2016 <br/>
 First production version for CERNBox: September 2017 (presented at [oCCon17](https://occon17.owncloud.org) - [slides](https://www.slideshare.net/giuseppelopresti/collaborative-editing-and-more-in-cernbox))<br/>
@@ -60,11 +61,13 @@ To run the tests, either run `pytest` if available in your system, or execute th
 
 ### Test against a Reva CS3 endpoint:
 
+The CS3 storage interface uses the [cs3 python client](https://github.com/cs3org/cs3-python-client), please also refer to its test suite and documentation.
+
 1. Clone reva (https://github.com/cs3org/reva)
 2. Run Reva according to <https://reva.link/docs/tutorials/share-tutorial/> (ie up until step 4 in the instructions)
+3. For a production deployment, configure your `wopiserver.conf` following the example above, and make sure the `iopsecret` file contains the same secret as configured in the [Reva appprovider](https://developer.sciencemesh.io/docs/technical-documentation/iop/iop-optional-configs/collabora-wopi-server/wopiserver)
 4. Configure `test/wopiserver-test.conf` such that the wopiserver can talk to your Reva instance: use [this example](docker/etc/wopiserver.cs3.conf) for a skeleton configuration
 5. Run the tests: `WOPI_STORAGE=cs3 python3 test/test_storageiface.py`
-3. For a production deployment, configure your `wopiserver.conf` following the example above, and make sure the `iopsecret` file contains the same secret as configured in the [Reva appprovider](https://developer.sciencemesh.io/docs/technical-documentation/iop/iop-optional-configs/collabora-wopi-server/wopiserver)
 
 ### Test against an Eos endpoint:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
-cs3client>=0.1
+cs3client>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ wheel>=0.38.0 # not directly required, pinned by Snyk to avoid a vulnerability
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
 werkzeug>=3.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cs3client>=0.1

--- a/src/core/commoniface.py
+++ b/src/core/commoniface.py
@@ -12,15 +12,16 @@ import json
 from base64 import urlsafe_b64encode, urlsafe_b64decode
 from binascii import Error as B64Error
 
+# Standard Linux error messages as also defined in cs3client.exceptions
 
-# standard file missing message
+# file missing message
 ENOENT_MSG = 'No such file or directory'
 
-# standard error thrown when attempting to overwrite a file/xattr in O_EXCL mode
+# error thrown when attempting to overwrite a file/xattr in O_EXCL mode
 # or when a lock operation cannot be performed because of failed preconditions
-EXCL_ERROR = 'File/xattr exists but EXCL mode requested, lock mismatch or lock expired'
+EXCL_ERROR = 'Lock mismatch'
 
-# standard error thrown when attempting an operation without the required access rights
+# attempt an operation without the required access rights
 ACCESS_ERROR = 'Operation not permitted'
 
 # name of the xattr storing the Reva lock

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -49,14 +49,19 @@ def init(inconfig, inlog):
 def healthcheck():
     """Probes the storage and returns a status message. For cs3 storage, we execute a call to ListAuthProviders"""
     try:
-        Auth(client).ListAuthProviders()
-        log.debug('msg="Executed ListAuthProviders as health check" endpoint="%s"' % (ctx["revagateway"]))
+        Auth(client).list_auth_providers()
+        log.debug('msg="Executed ListAuthProviders as health check" endpoint="%s"' % (config["cs3client"]["host"]))
         return "OK"
     except ConnectionError as e:
         log.error(
-            'msg="Health check: failed to call ListAuthProviders" endpoint="%s" error="%s"' % (ctx["revagateway"], e)
+            'msg="Health check: connection error when calling ListAuthProviders" endpoint="%s" error="%s"' % (config["cs3client"]["host"], e)
         )
-        return str(e)
+        return "FAIL"
+    except Exception as e:
+        log.error(
+            'msg="Health check: failed to call ListAuthProviders" endpoint="%s" error="%s"' % (config["cs3client"]["host"], e)
+        )
+        return "FAIL"
 
 
 def getuseridfromcreds(token, wopiuser):

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -149,8 +149,11 @@ def writefile(endpoint, filepath, userid, content, size, lockmd):
     and any pre-existing file is deleted (or moved to the previous version if supported).
     The islock flag is currently not supported. The backend should at least support
     writing the file with O_CREAT|O_EXCL flags to prevent races."""
+    app_name = lock_id = ''
+    if lockmd:
+        app_name, lock_id = lockmd
     resource = Resource.from_file_ref_and_endpoint(filepath, endpoint)
-    client.file.write_file(Auth.check_token(userid), resource, content, size, lockmd)
+    client.file.write_file(Auth.check_token(userid), resource, content, size, app_name, lock_id)
 
 
 def renamefile(endpoint, filepath, newfilepath, userid, lockmd):

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -1,501 +1,193 @@
-'''
+"""
 cs3iface.py
 
 CS3 API based interface for the IOP WOPI server
 
 Main author: Giuseppe.LoPresti@cern.ch, CERN/IT-ST
-'''
+"""
 
 import os
-import time
-import http
-import requests
-import grpc
 
 import cs3.storage.provider.v1beta1.resources_pb2 as cs3spr
-import cs3.storage.provider.v1beta1.provider_api_pb2 as cs3sp
-import cs3.auth.registry.v1beta1.registry_api_pb2 as cs3auth
 import cs3.gateway.v1beta1.gateway_api_pb2 as cs3gw
-import cs3.gateway.v1beta1.gateway_api_pb2_grpc as cs3gw_grpc
 import cs3.rpc.v1beta1.code_pb2 as cs3code
-import cs3.types.v1beta1.types_pb2 as types
-
+from cs3client import CS3Client
+from cs3resource import Resource
 import core.commoniface as common
 
 # key used if the `lockasattr` option is true, in order to store the lock payload without ensuring any lock semantic
-LOCK_ATTR_KEY = 'wopi.advlock'
+LOCK_ATTR_KEY = "wopi.advlock"
 
 # module-wide state
-ctx = {}            # "map" to store some module context: cf. init()
+ctx = {}  # "map" to store some module context: cf. init()
 log = None
+client = None  # client to interact with the CS3 API
 
 
 def init(inconfig, inlog):
-    '''Init module-level variables'''
-    global log     # pylint: disable=global-statement
+    """Init module-level variables"""
+    global config  # pylint: disable=global-statement
+    config = {}
+    global log  # pylint: disable=global-statement
     log = inlog
-    ctx['chunksize'] = inconfig.getint('io', 'chunksize')
-    ctx['ssl_verify'] = inconfig.getboolean('cs3', 'sslverify', fallback=True)
-    ctx['lockexpiration'] = inconfig.getint('general', 'wopilockexpiration')
-    ctx['lockasattr'] = inconfig.getboolean('cs3', 'lockasattr', fallback=False)
-    ctx['locknotimpl'] = False
-    ctx['revagateway'] = inconfig.get('cs3', 'revagateway')
-    ctx['grpc_timeout'] = inconfig.getint('cs3', "grpctimeout", fallback=10)
-    ctx['http_timeout'] = inconfig.getint('cs3', "httptimeout", fallback=10)
-    # prepare the gRPC channel and validate that the revagateway gRPC server is ready
-    try:
-        ch = grpc.insecure_channel(ctx['revagateway'])
-        grpc.channel_ready_future(ch).result(timeout=ctx['grpc_timeout'])
-    except grpc.FutureTimeoutError as e:
-        log.error('msg="Failed to connect to Reva via GRPC" error="%s"' % e)
-        raise IOError(e) from e
-    ctx['cs3gw'] = cs3gw_grpc.GatewayAPIStub(ch)
+    config["cs3client"]["host"] = inconfig.get("cs3", "revagateway")
+    config["cs3client"]["chunk_size"] = inconfig.getint("io", "chunksize")
+    config["cs3client"]["ssl_verify"] = inconfig.getboolean("cs3", "sslverify", fallback=True)
+    config["cs3client"]["lock_expiration"] = inconfig.getint("general", "wopilockexpiration")
+    config["cs3client"]["lock_as_attr"] = inconfig.getboolean("cs3", "lockasattr", fallback=False)
+    config["cs3client"]["lock_not_impl"] = False
+    config["cs3client"]["grpc_timeout"] = inconfig.getint("cs3", "grpctimeout", fallback=10)
+    config["cs3client"]["http_timeout"] = inconfig.getint("cs3", "httptimeout", fallback=10)
+    global client  # pylint: disable=global-statement
+    client = CS3Client(config, "cs3client", log)
 
 
 def healthcheck():
-    '''Probes the storage and returns a status message. For cs3 storage, we execute a call to ListAuthProviders'''
+    """Probes the storage and returns a status message. For cs3 storage, we execute a call to ListAuthProviders"""
     try:
-        res = ctx['cs3gw'].ListAuthProviders(request=cs3auth.ListAuthProvidersRequest())
-        log.debug('msg="Executed ListAuthProviders as health check" endpoint="%s" result="%s"' %
-                  (ctx['revagateway'], res.status))
-        return 'OK'
-    except grpc.RpcError as e:
-        log.error('msg="Health check: failed to call ListAuthProviders" endpoint="%s" error="%s"' %
-                  (ctx['revagateway'], e))
+        client.auth.ListAuthProviders()
+        log.debug('msg="Executed ListAuthProviders as health check" endpoint="%s"' % (ctx["revagateway"]))
+        return "OK"
+    except ConnectionError as e:
+        log.error(
+            'msg="Health check: failed to call ListAuthProviders" endpoint="%s" error="%s"' % (ctx["revagateway"], e)
+        )
         return str(e)
 
 
 def getuseridfromcreds(token, wopiuser):
-    '''Maps a Reva token and wopiuser to the credentials to be used to access the storage.
-    For the CS3 API case this is the token, and wopiuser is expected to be `username!userid_as_returned_by_stat`'''
-    return token, wopiuser.split('@')[0] + '!' + wopiuser
-
-
-def _getcs3reference(endpoint, fileref):
-    '''Generates a CS3 reference for a given fileref, covering the following cases:
-    absolute path, relative hybrid path, fully opaque fileid'''
-    # try splitting endpoint
-    parts = endpoint.split("$", 2)
-    endpoint = parts[0]
-    space_id = ""
-    if len(parts) == 2:
-        space_id = parts[1]
-
-    if fileref.find('/') == 0:
-        # assume we have an absolute path (works in Reva master, not in edge)
-        ref = cs3spr.Reference(path=fileref)
-    elif fileref.find('/') > 0:
-        # assume we have a relative path in the form `<parent_opaque_id>/<base_filename>`,
-        # also works if we get `<parent_opaque_id>/<path>/<filename>`
-        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, space_id=space_id,
-                                                             opaque_id=fileref[:fileref.find('/')]),
-                               path='.' + fileref[fileref.find('/'):])
-    else:
-        # assume we have an opaque fileid
-        ref = cs3spr.Reference(resource_id=cs3spr.ResourceId(storage_id=endpoint, space_id=space_id, opaque_id=fileref), path='.')
-    return ref
+    """Maps a Reva token and wopiuser to the credentials to be used to access the storage.
+    For the CS3 API case this is the token, and wopiuser is expected to be `username!userid_as_returned_by_stat`
+    """
+    return token, wopiuser.split("@")[0] + "!" + wopiuser
 
 
 def authenticate_for_test(userid, userpwd):
-    '''Use basic authentication against Reva for testing purposes'''
-    authReq = cs3gw.AuthenticateRequest(type='basic', client_id=userid, client_secret=userpwd)
-    authRes = ctx['cs3gw'].Authenticate(authReq)
+    """Use basic authentication against Reva for testing purposes"""
+    authReq = cs3gw.AuthenticateRequest(type="basic", client_id=userid, client_secret=userpwd)
+    authRes = client._gateway.Authenticate(authReq)  # pylint: disable=protected-access
     log.debug(f'msg="Authenticated user" userid="{authRes.user.id}"')
     if authRes.status.code != cs3code.CODE_OK:
-        raise IOError('Failed to authenticate as user ' + userid + ': ' + authRes.status.message)
+        raise IOError("Failed to authenticate as user " + userid + ": " + authRes.status.message)
     return authRes.token
 
 
-def stat(endpoint, fileref, userid, versioninv=1):
-    '''Stat a file and returns (size, mtime) as well as other extended info using the given userid as access token.
-    Note that endpoint here means the storage id, and fileref can be either a path in the form (parent_id/base_filename)
-    or a pure id (cf. _getcs3reference). The versioninv flag is natively supported by Reva.'''
-    tstart = time.time()
-    ref = _getcs3reference(endpoint, fileref)
-    statInfo = ctx['cs3gw'].Stat(request=cs3sp.StatRequest(ref=ref), metadata=[('x-access-token', userid)])
-    tend = time.time()
+def stat(endpoint, fileref, userid):
+    resource = Resource(endpoint, fileref)
+    client.auth.set_token(userid)
+    statInfo = client.file.stat(resource)
+    if statInfo.type == cs3spr.RESOURCE_TYPE_CONTAINER:
+        log.info(
+            'msg="Invoked stat" endpoint="%s" fileref="%s" trace="%s" result="ISDIR"'
+            % (endpoint, fileref, statInfo.status.trace)
+        )
+        raise IOError("Is a directory")
+    if statInfo.type not in (
+        cs3spr.RESOURCE_TYPE_FILE,
+        cs3spr.RESOURCE_TYPE_SYMLINK,
+    ):
+        log.warning(
+            'msg="Invoked stat" endpoint="%s" fileref="%s" unexpectedtype="%d"' % (endpoint, fileref, statInfo.type)
+        )
+        raise IOError("Unexpected type %d" % statInfo.type)
 
-    if statInfo.status.code == cs3code.CODE_NOT_FOUND:
-        log.info(f'msg="File not found" endpoint="{endpoint}" fileref="{fileref}" trace="{statInfo.status.trace}"')
-        raise IOError(common.ENOENT_MSG)
-    if statInfo.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed stat" endpoint="%s" fileref="%s" trace="%s" reason="%s"' %
-                  (endpoint, fileref, statInfo.status.trace, statInfo.status.message.replace('"', "'")))
-        raise IOError(statInfo.status.message)
-    if statInfo.info.type == cs3spr.RESOURCE_TYPE_CONTAINER:
-        log.info('msg="Invoked stat" endpoint="%s" fileref="%s" trace="%s" result="ISDIR"' %
-                 (endpoint, fileref, statInfo.status.trace))
-        raise IOError('Is a directory')
-    if statInfo.info.type not in (cs3spr.RESOURCE_TYPE_FILE, cs3spr.RESOURCE_TYPE_SYMLINK):
-        log.warning('msg="Invoked stat" endpoint="%s" fileref="%s" unexpectedtype="%d"' %
-                    (endpoint, fileref, statInfo.info.type))
-        raise IOError('Unexpected type %d' % statInfo.info.type)
-
-    inode = common.encodeinode(statInfo.info.id.storage_id, statInfo.info.id.opaque_id)
-    if statInfo.info.path[0] == '/':
+    inode = common.encodeinode(statInfo.id.storage_id, statInfo.id.opaque_id)
+    if statInfo.path[0] == "/":
         # we got an absolute path from Reva, use it
-        filepath = statInfo.info.path
+        filepath = statInfo.path
     else:
         # we got a relative path (actually, just the basename): build an hybrid path that can be used to reference
         # the file, using the parent_id that per specs MUST be available
-        filepath = statInfo.info.parent_id.opaque_id + '/' + os.path.basename(statInfo.info.path)
-    log.info('msg="Invoked stat" fileref="%s" trace="%s" inode="%s" filepath="%s" elapsedTimems="%.1f"' %
-             (fileref, statInfo.status.trace, inode, filepath, (tend-tstart)*1000))
-    # cache the xattrs map prior to returning; note we're never cleaning this cache and let it grow indefinitely
+        filepath = statInfo.parent_id.opaque_id + "/" + os.path.basename(statInfo.path)
     return {
-        'inode': inode,
-        'filepath': filepath,
-        'ownerid': statInfo.info.owner.opaque_id + '@' + statInfo.info.owner.idp,
-        'size': statInfo.info.size,
-        'mtime': statInfo.info.mtime.seconds,
-        'etag': statInfo.info.etag,
-        'xattrs': statInfo.info.arbitrary_metadata.metadata
+        "inode": inode,
+        "filepath": filepath,
+        "ownerid": statInfo.owner.opaque_id + "@" + statInfo.owner.idp,
+        "size": statInfo.size,
+        "mtime": statInfo.mtime.seconds,
+        "etag": statInfo.etag,
+        "xattrs": statInfo.arbitrary_metadata.metadata,
     }
 
 
-def statx(endpoint, fileref, userid, versioninv=1):
-    '''Get extended stat info (inode, filepath, ownerid, size, mtime, etag). Equivalent to stat.'''
-    return stat(endpoint, fileref, userid, versioninv)
+def statx(endpoint, fileref, userid):
+    """Get extended stat info (inode, filepath, ownerid, size, mtime, etag). Equivalent to stat."""
+    return stat(endpoint, fileref, userid)
 
 
 def setxattr(endpoint, filepath, userid, key, value, lockmd):
-    '''Set the extended attribute <key> to <value> using the given userid as access token'''
-    ref = _getcs3reference(endpoint, filepath)
-    md = cs3spr.ArbitraryMetadata()
-    md.metadata.update({key: str(value)})        # pylint: disable=no-member
-    lockid = None
-    if lockmd:
-        _, lockid = lockmd
-    req = cs3sp.SetArbitraryMetadataRequest(ref=ref, arbitrary_metadata=md, lock_id=lockid)
-    res = ctx['cs3gw'].SetArbitraryMetadata(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        # CS3 storages may refuse to set an xattr in case of lock mismatch: this is an overprotection,
-        # as the lock should concern the file's content, not its metadata, however we need to handle that
-        log.info('msg="Failed precondition on setxattr" filepath="%s" key="%s" trace="%s" reason="%s"' %
-                 (filepath, key, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to setxattr" filepath="%s" key="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, key, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked setxattr" result="{res}"')
+    """Set the extended attribute <key> to <value> using the given userid as access token"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.set_xattr(resource, key, value, lockmd)
 
 
 def rmxattr(endpoint, filepath, userid, key, lockmd):
-    '''Remove the extended attribute <key> using the given userid as access token'''
-    ref = _getcs3reference(endpoint, filepath)
-    lockid = None
-    if lockmd:
-        _, lockid = lockmd
-    req = cs3sp.UnsetArbitraryMetadataRequest(ref=ref, arbitrary_metadata_keys=[key], lock_id=lockid)
-    res = ctx['cs3gw'].UnsetArbitraryMetadata(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        log.info('msg="Failed precondition on rmxattr" filepath="%s" key="%s" trace="%s" reason="%s"' %
-                 (filepath, key, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to rmxattr" filepath="%s" trace="%s" key="%s" reason="%s"' %
-                  (filepath, key, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked rmxattr" result="{res.status}"')
-
-
-def setlock(endpoint, filepath, userid, appname, value):
-    '''Set a lock to filepath with the given value metadata and appname as holder'''
-    if ctx['lockasattr'] and ctx['locknotimpl']:
-        log.debug(f'msg="Using xattrs to execute setlock" filepath="{filepath}" value="{value}"')
-        try:
-            filemd = stat(endpoint, filepath, userid)
-            currvalue = filemd['xattrs'][LOCK_ATTR_KEY]
-            log.info('msg="Invoked setlock on an already locked entity" filepath="%s" appname="%s" previouslock="%s"' %
-                     (filepath, appname, currvalue))
-            raise IOError(common.EXCL_ERROR)
-        except KeyError:
-            expiration = int(time.time() + ctx['lockexpiration'])
-            setxattr(endpoint, filepath, userid, LOCK_ATTR_KEY, f'{appname}!{value}!{expiration}', None)
-            return
-
-    reference = _getcs3reference(endpoint, filepath)
-    lock = cs3spr.Lock(type=cs3spr.LOCK_TYPE_WRITE, app_name=appname, lock_id=value,
-                       expiration={'seconds': int(time.time() + ctx['lockexpiration'])})
-    req = cs3sp.SetLockRequest(ref=reference, lock=lock)
-    res = ctx['cs3gw'].SetLock(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        log.info('msg="Invoked setlock on an already locked entity" filepath="%s" appname="%s" trace="%s" reason="%s"' %
-                 (filepath, appname, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code == cs3code.CODE_UNIMPLEMENTED and ctx['lockasattr']:
-        ctx['locknotimpl'] = True
-        setlock(endpoint, filepath, userid, appname, value)
-        return
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to setlock" filepath="%s" appname="%s" value="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, appname, value, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked setlock" filepath="{filepath}" value="{value}" result="{res.status}"')
-
-
-def getlock(endpoint, filepath, userid):
-    '''Get the lock metadata for the given filepath'''
-    if ctx['lockasattr'] and ctx['locknotimpl']:
-        log.debug(f'msg="Using xattrs to execute getlock" filepath="{filepath}"')
-        try:
-            filemd = stat(endpoint, filepath, userid)
-            currvalue = filemd['xattrs'][LOCK_ATTR_KEY]
-            return {
-                'lock_id': currvalue.split('!')[1],
-                'type': 2,  # LOCK_TYPE_WRITE, though this is advisory!
-                'app_name': currvalue.split('!')[0],
-                'user': {},
-                'expiration': int(currvalue.split('!')[2])
-            }
-        except KeyError:
-            return None
-
-    reference = _getcs3reference(endpoint, filepath)
-    req = cs3sp.GetLockRequest(ref=reference)
-    res = ctx['cs3gw'].GetLock(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code == cs3code.CODE_NOT_FOUND:
-        log.debug(f'msg="Invoked getlock on unlocked or missing file" filepath="{filepath}"')
-        return None
-    if res.status.code == cs3code.CODE_UNIMPLEMENTED and ctx['lockasattr']:
-        ctx['locknotimpl'] = True
-        return getlock(endpoint, filepath, userid)
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to getlock" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked getlock" filepath="{filepath}" result="{res.lock}"')
-    # rebuild a dict corresponding to the internal JSON structure used by Reva, cf. commoniface.py
-    return {
-        'lock_id': res.lock.lock_id,
-        'type': res.lock.type,
-        'app_name': res.lock.app_name,
-        'user': {
-            'opaque_id': res.lock.user.opaque_id,
-            'idp': res.lock.user.idp,
-            'type': res.lock.user.type
-        } if res.lock.user.opaque_id else {},
-        'expiration': {
-            'seconds': res.lock.expiration.seconds
-        }
-    }
-
-
-def refreshlock(endpoint, filepath, userid, appname, value, oldvalue=None):
-    '''Refresh the lock metadata for the given filepath'''
-    if ctx['lockasattr'] and ctx['locknotimpl']:
-        log.debug(f'msg="Using xattrs to execute setlock" filepath="{filepath}" value="{value}"')
-        try:
-            filemd = stat(endpoint, filepath, userid)
-            currvalue = filemd['xattrs'][LOCK_ATTR_KEY]
-            if currvalue.split('!')[0] == appname and (not oldvalue or currvalue.split('!')[1] == oldvalue):
-                raise KeyError
-            log.info('msg="Failed precondition on refreshlock" filepath="%s" appname="%s" previouslock="%s"' %
-                     (filepath, appname, currvalue))
-            raise IOError(common.EXCL_ERROR)
-        except KeyError:
-            expiration = int(time.time() + ctx['lockexpiration'])
-            setxattr(endpoint, filepath, userid, LOCK_ATTR_KEY, f'{appname}!{value}!{expiration}', None)
-            return
-
-    reference = _getcs3reference(endpoint, filepath)
-    lock = cs3spr.Lock(type=cs3spr.LOCK_TYPE_WRITE, app_name=appname, lock_id=value,
-                       expiration={'seconds': int(time.time() + ctx['lockexpiration'])})
-    req = cs3sp.RefreshLockRequest(ref=reference, lock=lock, existing_lock_id=oldvalue)
-    res = ctx['cs3gw'].RefreshLock(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        log.info('msg="Failed precondition on refreshlock" filepath="%s" appname="%s" trace="%s" reason="%s"' %
-                 (filepath, appname, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code == cs3code.CODE_UNIMPLEMENTED and ctx['lockasattr']:
-        ctx['locknotimpl'] = True
-        refreshlock(endpoint, filepath, userid, appname, value, oldvalue)
-        return
-    if res.status.code != cs3code.CODE_OK:
-        log.warning('msg="Failed to refreshlock" filepath="%s" appname="%s" value="%s" trace="%s" code="%s" reason="%s"' %
-                    (filepath, appname, value, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked refreshlock" filepath="{filepath}" value="{value}" result="{res.status}"')
-
-
-def unlock(endpoint, filepath, userid, appname, value):
-    '''Remove the lock for the given filepath'''
-    if ctx['lockasattr'] and ctx['locknotimpl']:
-        log.debug(f'msg="Using xattrs to execute unlock" filepath="{filepath}" value="{value}"')
-        try:
-            filemd = stat(endpoint, filepath, userid)
-            currvalue = filemd['xattrs'][LOCK_ATTR_KEY]
-            if currvalue.split('!')[0] == appname and currvalue.split('!')[1] == value:
-                raise KeyError
-            log.info('msg="Failed precondition on unlock" filepath="%s" appname="%s" previouslock="%s"' %
-                     (filepath, appname, currvalue))
-            raise IOError(common.EXCL_ERROR)
-        except KeyError:
-            rmxattr(endpoint, filepath, userid, LOCK_ATTR_KEY, None)
-            return
-
-    reference = _getcs3reference(endpoint, filepath)
-    lock = cs3spr.Lock(type=cs3spr.LOCK_TYPE_WRITE, app_name=appname, lock_id=value)
-    req = cs3sp.UnlockRequest(ref=reference, lock=lock)
-    res = ctx['cs3gw'].Unlock(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        log.info('msg="Failed precondition on unlock" filepath="%s" appname="%s" trace="%s" reason="%s"' %
-                 (filepath, appname, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code == cs3code.CODE_UNIMPLEMENTED and ctx['lockasattr']:
-        ctx['locknotimpl'] = True
-        unlock(endpoint, filepath, userid, appname, value)
-        return
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to unlock" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked unlock" filepath="{filepath}" value="{value}" result="{res.status}"')
+    """Remove the extended attribute <key> using the given userid as access token"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.remove_xattr(resource, key, lockmd)
 
 
 def readfile(endpoint, filepath, userid, lockid):
-    '''Read a file using the given userid as access token. Note that the function is a generator, managed by the app server.'''
-    tstart = time.time()
-    reference = _getcs3reference(endpoint, filepath)
-
-    # prepare endpoint
-    req = cs3sp.InitiateFileDownloadRequest(ref=reference, lock_id=lockid)
-    res = ctx['cs3gw'].InitiateFileDownload(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code == cs3code.CODE_NOT_FOUND:
-        log.info(f'msg="File not found on read" filepath="{filepath}"')
-        yield IOError(common.ENOENT_MSG)
-    elif res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to initiateFileDownload on read" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        yield IOError(res.status.message)
-    tend = time.time()
-    log.debug('msg="readfile: InitiateFileDownloadRes returned" trace="%s" protocols="%s"' %
-              (res.status.trace, res.protocols))
-
-    # Download
-    try:
-        protocol = [p for p in res.protocols if p.protocol in ["simple", "spaces"]][0]
-        headers = {
-            'X-Access-Token': userid,
-            'X-Reva-Transfer': protocol.token
-        }
-        fileget = requests.get(url=protocol.download_endpoint, headers=headers,
-                               verify=ctx['ssl_verify'], timeout=ctx['http_timeout'],
-                               stream=True)
-    except requests.exceptions.RequestException as e:
-        log.error(f'msg="Exception when downloading file from Reva" reason="{e}"')
-        yield IOError(e)
-    data = fileget.iter_content(ctx['chunksize'])
-    if fileget.status_code != http.client.OK:
-        log.error('msg="Error downloading file from Reva" code="%d" reason="%s"' %
-                  (fileget.status_code, fileget.reason.replace('"', "'")))
-        yield IOError(fileget.reason)
-    else:
-        log.info(f'msg="File open for read" filepath="{filepath}" elapsedTimems="{(tend - tstart) * 1000:.1f}"')
-        for chunk in data:
-            yield chunk
+    """Read a file using the given userid as access token. Note that the function is a generator, managed by the app server."""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    data = client.file.read_file(resource, lockid)
+    for chunk in data:
+        yield chunk
 
 
-def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):
-    '''Write a file using the given userid as access token. The entire content is written
+def writefile(endpoint, filepath, userid, content, size, lockmd):
+    """Write a file using the given userid as access token. The entire content is written
     and any pre-existing file is deleted (or moved to the previous version if supported).
     The islock flag is currently not supported. The backend should at least support
-    writing the file with O_CREAT|O_EXCL flags to prevent races.'''
-    tstart = time.time()
-    if islock:
-        log.warning('msg="Lock (no-overwrite) flag not supported, going for standard upload"')
-    if lockmd:
-        appname, lockid = lockmd
-    else:
-        appname = lockid = ''
-
-    # prepare endpoint
-    if size == -1:
-        if isinstance(content, str):
-            content = bytes(content, 'UTF-8')
-        size = len(content)
-    reference = _getcs3reference(endpoint, filepath)
-    req = cs3sp.InitiateFileUploadRequest(ref=reference, lock_id=lockid, opaque=types.Opaque(
-        map={'Upload-Length': types.OpaqueEntry(decoder='plain', value=str.encode(str(size)))}))
-    res = ctx['cs3gw'].InitiateFileUpload(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code == cs3code.CODE_FAILED_PRECONDITION:
-        log.info('msg="Lock mismatch uploading file" filepath="%s" reason="%s"' %
-                 (filepath, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to initiateFileUpload on write" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    tend = time.time()
-    log.debug('msg="writefile: InitiateFileUploadRes returned" trace="%s" protocols="%s"' %
-              (res.status.trace, res.protocols))
-
-    # Upload
-    try:
-        protocol = [p for p in res.protocols if p.protocol in ["simple", "spaces"]][0]
-        headers = {
-            'X-Access-Token': userid,
-            'Upload-Length': str(size),
-            'X-Reva-Transfer': protocol.token,
-            'X-Lock-Id': lockid,
-            'X-Lock-Holder': appname,
-        }
-        putres = requests.put(url=protocol.upload_endpoint, data=content, headers=headers,
-                              verify=ctx['ssl_verify'], timeout=ctx['http_timeout'])
-    except requests.exceptions.RequestException as e:
-        log.error(f'msg="Exception when uploading file to Reva" reason="{e}"')
-        raise IOError(e) from e
-    if putres.status_code == http.client.CONFLICT:
-        log.info(f'msg="Got conflict on PUT, file is locked" reason="{putres.reason}" filepath="{filepath}"')
-        raise IOError(common.EXCL_ERROR)
-    if putres.status_code == http.client.UNAUTHORIZED:
-        log.warning(f'msg="Access denied uploading file to Reva" reason="{putres.reason}" filepath="{filepath}"')
-        raise IOError(common.ACCESS_ERROR)
-    if putres.status_code != http.client.OK:
-        if size == 0:  # 0-byte file uploads may have been finalized after InitiateFileUploadRequest, let's assume it's OK
-            # TODO this use-case is to be reimplemented with a call to `TouchFile`.
-            log.info('msg="0-byte file written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %
-                     (filepath, (tend - tstart) * 1000, islock))
-            return
-
-        log.error('msg="Error uploading file to Reva" code="%d" reason="%s"' % (putres.status_code, putres.reason))
-        raise IOError(putres.reason)
-    log.info('msg="File written successfully" filepath="%s" elapsedTimems="%.1f" islock="%s"' %
-             (filepath, (tend - tstart) * 1000, islock))
+    writing the file with O_CREAT|O_EXCL flags to prevent races."""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.write_file(resource, content, size, lockmd)
 
 
 def renamefile(endpoint, filepath, newfilepath, userid, lockmd):
-    '''Rename a file from origfilepath to newfilepath using the given userid as access token.'''
-    reference = _getcs3reference(endpoint, filepath)
-    newfileref = _getcs3reference(endpoint, newfilepath)
-    lockid = None
-    if lockmd:
-        _, lockid = lockmd
-    req = cs3sp.MoveRequest(source=reference, destination=newfileref, lock_id=lockid)
-    res = ctx['cs3gw'].Move(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code in [cs3code.CODE_FAILED_PRECONDITION, cs3code.CODE_ABORTED]:
-        log.info('msg="Failed precondition on rename" filepath="%s" trace="%s" reason="%s"' %
-                 (filepath, res.status.trace, res.status.message.replace('"', "'")))
-        raise IOError(common.EXCL_ERROR)
-    if res.status.code != cs3code.CODE_OK:
-        log.error('msg="Failed to rename file" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked renamefile" result="{res}"')
+    """Rename a file from origfilepath to newfilepath using the given userid as access token."""
+    resource = Resource(endpoint, filepath)
+    new_resource = Resource(endpoint, newfilepath)
+    client.auth.set_token(userid)
+    client.file.rename_file(resource, new_resource, lockmd)
 
 
-def removefile(endpoint, filepath, userid, _force=False):
-    '''Remove a file using the given userid as access token.
-       The force argument is ignored for now for CS3 storage.'''
-    reference = _getcs3reference(endpoint, filepath)
-    req = cs3sp.DeleteRequest(ref=reference)
-    res = ctx['cs3gw'].Delete(request=req, metadata=[('x-access-token', userid)])
-    if res.status.code != cs3code.CODE_OK:
-        if 'path not found' in str(res):
-            log.info(f'msg="Invoked removefile on non-existing file" filepath="{filepath}"')
-            raise IOError(common.ENOENT_MSG)
-        log.error('msg="Failed to remove file" filepath="%s" trace="%s" code="%s" reason="%s"' %
-                  (filepath, res.status.trace, res.status.code, res.status.message.replace('"', "'")))
-        raise IOError(res.status.message)
-    log.debug(f'msg="Invoked removefile" result="{res}"')
+def removefile(endpoint, filepath, userid):
+    """Remove a file using the given userid as access token.
+    The force argument is ignored for now for CS3 storage."""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.remove_file(resource)
+
+
+def setlock(endpoint, filepath, userid, appname, value):
+    """Set a lock to filepath with the given value metadata and appname as holder"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.set_lock(resource, app_name=appname, value=value)
+
+
+def refreshlock(endpoint, filepath, userid, appname, value, oldvalue=None):
+    """Refresh the lock metadata for the given filepath"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.refresh_lock(resource, app_name=appname, value=value, old_value=oldvalue)
+
+
+def getlock(endpoint, filepath, userid):
+    """Get the lock metadata for the given filepath"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    lock = client.file.get_lock(resource)
+    return lock
+
+
+def unlock(endpoint, filepath, userid, appname, value):
+    """Remove the lock for the given filepath"""
+    resource = Resource(endpoint, filepath)
+    client.auth.set_token(userid)
+    client.file.unlock(resource, app_name=appname, value=value)

--- a/src/core/cs3iface.py
+++ b/src/core/cs3iface.py
@@ -124,7 +124,7 @@ def setxattr(endpoint, filepath, userid, key, value, lockmd):
     if lockmd:
         _, lock_id = lockmd
     resource = Resource.from_file_ref_and_endpoint(filepath, endpoint)
-    client.file.set_xattr(Auth.check_token(userid), resource, key, value, lock_id)
+    client.file.set_xattr(Auth.check_token(userid), resource, key, str(value), lock_id)
 
 
 def rmxattr(endpoint, filepath, userid, key, lockmd):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -237,14 +237,13 @@ def readfile(_endpoint, filepath, _userid, _lockid):
             # the actual read is buffered and managed by the app server
             for chunk in iter(lambda: f.read(chunksize), b''):
                 yield chunk
-    except FileNotFoundError:
+    except FileNotFoundError as fnfe:
         # log this case as info to keep the logs cleaner
         log.info(f'msg="File not found on read" filepath="{filepath}"')
-        # as this is a generator, we yield the error string instead of the file's contents
-        yield IOError('No such file or directory')
+        raise IOError('No such file or directory') from fnfe
     except OSError as e:
         log.error(f'msg="Error opening the file for read" filepath="{filepath}" error="{e}"')
-        yield IOError(e)
+        raise IOError(e) from e
 
 
 def writefile(endpoint, filepath, userid, content, size, lockmd, islock=False):

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -123,9 +123,8 @@ def stat(_endpoint, filepath, _userid):
         raise IOError(e) from e
 
 
-def statx(endpoint, filepath, userid, versioninv=1):
-    '''Get extended stat info (inode, filepath, ownerid, size, mtime). Equivalent to stat in the case of local storage.
-    The versioninv flag is ignored as local storage always supports version-invariant inodes (cf. CERNBOX-1216).'''
+def statx(endpoint, filepath, userid):
+    '''Get extended stat info (inode, filepath, ownerid, size, mtime). Equivalent to stat in the case of local storage'''
     return stat(endpoint, filepath, userid)
 
 

--- a/src/core/localiface.py
+++ b/src/core/localiface.py
@@ -104,7 +104,7 @@ def stat(_endpoint, filepath, _userid):
         try:
             xattrs = {
                 k.strip('user.'): os.getxattr(_getfilepath(filepath), k).decode()
-                    for k in os.listxattr(_getfilepath(filepath))
+                for k in os.listxattr(_getfilepath(filepath))
             }
         except OSError as e:
             log.info('msg="Failed to invoke listxattr/getxattr" inode="%d" filepath="%s" exception="%s"' %

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from urllib.parse import unquote_plus as url_unquote
 from urllib.parse import quote_plus as url_quote
 from urllib.parse import urlparse
-from more_itertools import peekable
 import flask
 import core.wopiutils as utils
 import core.commoniface as common

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -591,7 +591,7 @@ def putFile(fileid, acctok):
     try:
         if srv.config.get('general', 'detectexternalmodifications', fallback='True').upper() == 'TRUE':
             # check now the destination file against conflicts if required
-            statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'], versioninv=1)
+            statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'])
             savetime = statInfo['xattrs'].get(utils.LASTSAVETIMEKEY)
             mtime = statInfo['mtime']
             if not savetime or not savetime.isdigit() or int(savetime) < int(mtime):
@@ -609,7 +609,7 @@ def putFile(fileid, acctok):
         # Also, note we can't get a time resolution better than one second!
         # Anyhow, the EFSS should support versioning for such cases.
         utils.storeWopiFile(acctok, retrievedLock, utils.LASTSAVETIMEKEY)
-        statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'], versioninv=1)
+        statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'])
         log.info('msg="File stored successfully" action="edit" user="%s" filename="%s" version="%s" token="%s"' %
                  (acctok['userid'][-20:], acctok['filename'], statInfo['etag'], flask.request.args['access_token'][-20:]))
         resp = flask.Response()

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -287,9 +287,6 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefn=None):
             # then try to read a LibreOffice lock
             lolockstat = st.statx(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], versioninv=0)
             lolock = next(st.readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], None))
-            if isinstance(lolock, IOError):
-                # this might be an access error, optimistically move on
-                raise lolock
             lolock = lolock.decode()
             if 'WOPIServer' not in lolock:
                 lolockholder = lolock.split(',')[1] if ',' in lolock else lolockstat['ownerid']

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -285,7 +285,7 @@ def retrieveWopiLock(fileid, operation, lockforlog, acctok, overridefn=None):
             pass
         try:
             # then try to read a LibreOffice lock
-            lolockstat = st.statx(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], versioninv=0)
+            lolockstat = st.statx(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'])
             lolock = next(st.readfile(acctok['endpoint'], getLibreOfficeLockName(acctok['filename']), acctok['userid'], None))
             lolock = lolock.decode()
             if 'WOPIServer' not in lolock:

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -436,11 +436,11 @@ def readfile(endpoint, filepath, userid, _lockid):
             # the file could not be opened: check the case of ENOENT and log it as info to keep the logs cleaner
             if common.ENOENT_MSG in rc.message:
                 log.info(f'msg="File not found on read" filepath="{filepath}"')
-                yield IOError(common.ENOENT_MSG)
+                raise IOError(common.ENOENT_MSG)
             else:
                 log.error('msg="Error opening the file for read" filepath="%s" code="%d" error="%s"' %
                           (filepath, rc.shellcode, rc.message.strip('\n')))
-                yield IOError(rc.message)
+                raise IOError(rc.message)
         else:
             log.info(f'msg="File open for read" filepath="{filepath}" elapsedTimems="{(tend - tstart) * 1000:.1f}"')
             chunksize = config.getint('io', 'chunksize')

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -197,9 +197,8 @@ def stat(endpoint, filepath, userid):
     return {'size': statInfo.size, 'mtime': statInfo.modtime}
 
 
-def statx(endpoint, fileref, userid, versioninv=1):
+def statx(endpoint, fileref, userid):
     '''Get extended stat info (inode, filepath, ownerid, size, mtime) via an xroot opaque query on behalf of the given userid.
-    If versioninv=0, the logic to support the version folder is not triggered.
     If the given fileref is an inode, it is resolved to a full path.'''
     tstart = time.time()
     if fileref[0] != '/':
@@ -254,21 +253,6 @@ def statx(endpoint, fileref, userid, versioninv=1):
     if 'treesize' in statxdata:
         raise IOError('Is a directory')      # EISDIR
 
-    if versioninv == 0:
-        # statx info of the given file:
-        # we extract the eosinstance from endpoint, which looks like e.g. root://eosinstance[.cern.ch]
-        endpoint = _geturlfor(endpoint)
-        inode = common.encodeinode(endpoint[7:] if endpoint.find('.') == -1 else endpoint[7:endpoint.find('.')], statxdata['ino'])
-        log.debug(f'msg="Invoked stat return" inode="{inode}" filepath="{_getfilepath(filepath)}"')
-        return {
-            'inode': inode,
-            'filepath': filepath,
-            'ownerid': statxdata['uid'] + ':' + statxdata['gid'],
-            'size': int(statxdata['size']),
-            'mtime': int(float(statxdata['mtime'])),
-            'etag': statxdata['etag'],
-            'xattrs': xattrs,
-        }
     # now stat the corresponding version folder to get an inode invariant to save operations, see CERNBOX-1216
     # also, use the owner's as opposed to the user's credentials to bypass any restriction (e.g. with single-share files)
     verFolder = os.path.dirname(filepath) + os.path.sep + EOSVERSIONPREFIX + os.path.basename(filepath)

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -243,7 +243,7 @@ def statx(endpoint, fileref, userid, versioninv=1):
         statxdata = {k.decode(): v.decode().strip('"') for k, v in
                      [kv for kv in kvlist if len(kv) == 2 and kv[0].find(b'xattr') == -1]}
         for ikv, kv in enumerate(kvlist):
-            if len(kv) == 2 and kv[0].find(b'xattrn') and kv[1].find(b'user.'):
+            if len(kv) == 2 and kv[0].find(b'xattrn') == 0 and kv[1].find(b'user.') == 0:
                 # we found an user xattr: use it as key, where the value is on the next element (with kv[0] = 'xattrv')
                 xattrs[kv[1].decode().strip('user.')] = kvlist[ikv+1][1].decode()
 

--- a/src/core/xrootiface.py
+++ b/src/core/xrootiface.py
@@ -218,28 +218,42 @@ def statx(endpoint, fileref, userid, versioninv=1):
         filepath = filepath.decode().replace(EOSVERSIONPREFIX, '').replace('#and#', '&')
     else:
         filepath = fileref
+
     # stat with the -m flag, so to obtain a k=v list
     statInfo = _xrootcmd(endpoint, 'fileinfo', '', userid, 'mgm.path=' + _getfilepath(filepath, encodeamp=True)
                          + '&mgm.pcmd=fileinfo&mgm.file.info.option=-m')
+    xattrs = {}
     try:
         # output looks like:
-        # keylength.file=35 file=/eos/.../filename size=2915 mtime=1599649863.0 ctime=1599649866.280468540
-        # btime=1599649866.280468540 clock=0 mode=0644 uid=xxxx gid=xxxx fxid=19ab8b68 fid=430672744 ino=115607834422411264
-        # pid=1713958 pxid=001a2726 xstype=adler xs=a2dfcdf9 etag="115607834422411264:a2dfcdf9" detached=0 layout=replica
-        # nstripes=2 lid=00100112 nrep=2 xattrn=sys.eos.btime xattrv=1599649866.280468540 uid:xxxx[username] gid:xxxx[group]
-        # tident:xxx name:username dn: prot:https host:xxxx.cern.ch domain:cern.ch geo: sudo:0 fsid=305 fsid=486
+        # keylength.file=60 file=/eos/.../file name with spaces size=49322 status=healthy mtime=1722868599.312924544
+        # ctime=1722868599.371644799 btime=1722868599.312743733 atime=1722868599.312744021 clock=0 mode=0644 uid=55375 gid=2763
+        # fxid=1fef0b88 fid=535759752 ino=143816913334566912 pid=21195331 pxid=01436a43 xstype=adler xs=7fd2729c
+        # etag="143816913334566912:7fd2729c" detached=0 layout=replica nstripes=2 lid=00100112 nrep=2
+        # xattrn=sys.eos.btime xattrv=1722868599.312743733
+        # xattrn=sys.fs.tracking xattrv=+648+260
+        # xattrn=sys.fusex.state xattrv=<non-decodable>
+        # xattrn=sys.utrace xattrv=2012194c-5338-11ef-b295-a4bf0179682d
+        # xattrn=sys.vtrace xattrv=[Mon Aug  5 16:36:39 2024] uid:55375[xxxx] gid:2763[xx] tident:root.11:2881@...
+        # xattrn=user.iop.wopi.lastwritetime xattrv=1722868599
+        # fsid=648 fsid=260
         # cf. https://gitlab.cern.ch/dss/eos/-/blob/master/archive/eosarch/utils.py
         kvlist = [kv.split(b'=') for kv in statInfo.split()]
-        # extract the key-value pairs, but drop the xattrn/xattrv ones as not needed and potentially containing
-        # non-unicode-decodable content (cf. CERNBOX-3514)
+        # extract the key-value pairs for the core metadata and the user xattrs; drop the rest, don't decode as
+        # some sys xattrs may contain non-unicode-decodable content (cf. CERNBOX-3514)
         statxdata = {k.decode(): v.decode().strip('"') for k, v in
                      [kv for kv in kvlist if len(kv) == 2 and kv[0].find(b'xattr') == -1]}
+        for ikv, kv in enumerate(kvlist):
+            if len(kv) == 2 and kv[0].find(b'xattrn') and kv[1].find(b'user.'):
+                # we found an user xattr: use it as key, where the value is on the next element (with kv[0] = 'xattrv')
+                xattrs[kv[1].decode().strip('user.')] = kvlist[ikv+1][1].decode()
+
     except ValueError as e:
         # UnicodeDecodeError exceptions would fall here
         log.error(f'msg="Invoked fileinfo but failed to parse output" result="{statInfo}" exception="{e}"')
         raise IOError('Failed to parse fileinfo response') from e
     if 'treesize' in statxdata:
         raise IOError('Is a directory')      # EISDIR
+
     if versioninv == 0:
         # statx info of the given file:
         # we extract the eosinstance from endpoint, which looks like e.g. root://eosinstance[.cern.ch]
@@ -253,6 +267,7 @@ def statx(endpoint, fileref, userid, versioninv=1):
             'size': int(statxdata['size']),
             'mtime': int(float(statxdata['mtime'])),
             'etag': statxdata['etag'],
+            'xattrs': xattrs,
         }
     # now stat the corresponding version folder to get an inode invariant to save operations, see CERNBOX-1216
     # also, use the owner's as opposed to the user's credentials to bypass any restriction (e.g. with single-share files)
@@ -261,6 +276,7 @@ def statx(endpoint, fileref, userid, versioninv=1):
     rcv, infov = _getxrdfor(endpoint).query(QueryCode.OPAQUEFILE, _getfilepath(verFolder) + ownerarg + '&mgm.pcmd=stat',
                                             timeout=timeout)
     tend = time.time()
+
     try:
         if not infov:
             raise IOError(f'xrdquery returned nothing, rcv={rcv}')
@@ -286,6 +302,7 @@ def statx(endpoint, fileref, userid, versioninv=1):
     except (IOError, UnicodeDecodeError) as e:
         log.error(f'msg="Failed to mkdir/stat version folder" filepath="{_getfilepath(filepath)}" error="{e}"')
         raise IOError(e) from e
+
     # return the metadata of the given file, with the inode taken from the version folder
     endpoint = _geturlfor(endpoint)
     inode = common.encodeinode(endpoint[7:] if endpoint.find('.') == -1 else endpoint[7:endpoint.find('.')], statxdata['ino'])
@@ -297,6 +314,7 @@ def statx(endpoint, fileref, userid, versioninv=1):
         'size': int(statxdata['size']),
         'mtime': int(float(statxdata['mtime'])),
         'etag': statxdata['etag'],
+        'xattrs': xattrs,
     }
 
 
@@ -313,9 +331,8 @@ def setxattr(endpoint, filepath, _userid, key, value, lockmd):
               + '&mgm.path=' + _getfilepath(filepath, encodeamp=True), appname)
 
 
-def getxattr(endpoint, filepath, _userid, key):
-    '''Get the extended attribute <key> via a special open.
-    The userid is overridden to make sure it also works on shared files.'''
+def _getxattr(endpoint, filepath, key):
+    '''Internal only: get the extended attribute <key> via a special open.'''
     if 'user' not in key and 'sys' not in key:
         # if nothing is given, assume it's a user attr
         key = 'user.' + key
@@ -364,7 +381,7 @@ def setlock(endpoint, filepath, userid, appname, value, recurse=False):
 
 def getlock(endpoint, filepath, userid):
     '''Get the lock metadata as an xattr'''
-    rawl = getxattr(endpoint, filepath, userid, common.LOCKKEY)
+    rawl = _getxattr(endpoint, filepath, common.LOCKKEY)
     if rawl:
         lock = common.retrieverevalock(rawl)
         if lock['expiration']['seconds'] > time.time():

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -105,6 +105,7 @@ class TestStorage(unittest.TestCase):
         self.assertTrue('size' in statInfo, 'Missing size from stat output')
         self.assertTrue('mtime' in statInfo, 'Missing mtime from stat output')
         self.assertTrue('etag' in statInfo, 'Missing etag from stat output')
+        self.assertTrue('xattrs' in statInfo, 'Missing xattrs from stat output')
         self.storage.removefile(self.endpoint, self.homepath + '/test.txt', self.userid)
 
     def test_statx_invariant_fileid(self):
@@ -372,11 +373,11 @@ class TestStorage(unittest.TestCase):
         self.storage.setlock(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'test app', 'xattrlock')
         self.storage.setxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', 123,
                               ('test app', 'xattrlock'))
-        v = self.storage.getxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey')
-        self.assertEqual(v, '123')
+        fmd = self.storage.statx(self.endpoint, self.homepath + '/test&xattr.txt', self.userid)
+        self.assertEqual(fmd['xattrs']['testkey'], '123')
         self.storage.rmxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey', ('test app', 'xattrlock'))
-        v = self.storage.getxattr(self.endpoint, self.homepath + '/test&xattr.txt', self.userid, 'testkey')
-        self.assertEqual(v, None)
+        fmd = self.storage.statx(self.endpoint, self.homepath + '/test&xattr.txt', self.userid)
+        self.assertIsNone(fmd['xattrs'].get('testkey'))
         self.storage.removefile(self.endpoint, self.homepath + '/test&xattr.txt', self.userid)
 
     def test_rename_statx(self):

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -178,7 +178,7 @@ class TestStorage(unittest.TestCase):
     def test_write_islock(self):
         '''Test double write with the islock flag'''
         if self.storagetype == 'cs3':
-            self.log.warn('Skipping test_write_islock for storagetype cs3')
+            self.log.warning('Skipping test_write_islock for storagetype cs3')
             return
         try:
             self.storage.removefile(self.endpoint, self.homepath + '/testoverwrite', self.userid)
@@ -195,7 +195,7 @@ class TestStorage(unittest.TestCase):
     def test_write_race(self):
         '''Test multithreaded double write with the islock flag. Might fail as it relies on tight timing'''
         if self.storagetype == 'cs3':
-            self.log.warn('Skipping test_write_race for storagetype cs3')
+            self.log.warning('Skipping test_write_race for storagetype cs3')
             return
         try:
             self.storage.removefile(self.endpoint, self.homepath + '/testwriterace', self.userid)

--- a/test/test_storageiface.py
+++ b/test/test_storageiface.py
@@ -98,7 +98,7 @@ class TestStorage(unittest.TestCase):
     def test_statx_fileid(self):
         '''Call statx() and test if fileid-based stat is supported'''
         self.storage.writefile(self.endpoint, self.homepath + '/test.txt', self.userid, databuf, -1, None)
-        statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid, versioninv=0)
+        statInfo = self.storage.statx(self.endpoint, self.homepath + '/test.txt', self.userid)
         self.assertTrue('inode' in statInfo, 'Missing inode from statx output')
         self.assertTrue('filepath' in statInfo, 'Missing filepath from statx output')
         self.assertTrue('ownerid' in statInfo, 'Missing ownerid from stat output')


### PR DESCRIPTION
This PR is to introduce the https://github.com/cs3org/cs3-python-client library contributed by @rawe0.

As part of this, some refactoring and simplification has taken place:
* Simplified xattrs handling: dropped the need for an independent `getxattr()` API, as well as the caching recently introduced, as the xattrs are always queried next to a stat call.
* Removed `versioninv` flag on stat, assuming it's always version invariant. Only xroot was able to make a distinction.
* Standardized `readfile` that now raises an exception instead of `yield`ing it. Consequently dropped the `peek` logic.
* Standardized error messages.

@micbar a heads-up about a larger-than-usual change.

Remaining tasks:
- [x] Push `cs3client >= 1.1` as requirement
- [ ] Test with the Microsoft WOPI validator