### PR TITLE
Disable ExportAs and SaveAs for collabora

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -119,6 +119,7 @@ def checkFileInfo(fileid, acctok):
         # extensions for Collabora Online
         if acctok['appname'] == 'Collabora':
             fmd['EnableOwnerTermination'] = True
+            fmd['UserCanNotWriteRelative'] = True
             fmd['DisableExport'] = fmd['DisableCopy'] = fmd['DisablePrint'] = acctok['viewmode'] == utils.ViewMode.VIEW_ONLY
 
         res = flask.Response(json.dumps(fmd), mimetype='application/json')


### PR DESCRIPTION
We want to disable ExportAs and SaveAs in Collabora because the CERNBox doesn't have support for this functionality. 