### PR TITLE
Introduce apps config section and option for Collabora

### DIFF
--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -118,11 +118,14 @@ def checkFileInfo(fileid, acctok):
             # if no WebDAV URL is provided, ignore this setting
             pass
         # extensions for Collabora Online
-        if acctok['appname'] == 'Collabora':
+        if 'Collabora' in acctok['appname']:
             fmd['EnableOwnerTermination'] = True
             fmd['DisableExport'] = fmd['DisableCopy'] = fmd['DisablePrint'] = acctok['viewmode'] == utils.ViewMode.VIEW_ONLY
+            if srv.config.get('apps', 'codedisableexport', fallback='False').upper() == 'TRUE':
+                fmd['UserCanNotWriteRelative'] = fmd['DisableExport'] = True
 
         res = flask.Response(json.dumps(fmd), mimetype='application/json')
+
         # redact sensitive metadata for the logs
         if srv.config.get('general', 'loglevel') != 'Debug':
             fmd['HostViewUrl'] = fmd['HostEditUrl'] = fmd['DownloadUrl'] = fmd['FileUrl'] = \

--- a/src/core/wopi.py
+++ b/src/core/wopi.py
@@ -34,6 +34,7 @@ def checkFileInfo(fileid, acctok):
         acctok['viewmode'] = utils.ViewMode(acctok['viewmode'])
         acctok['usertype'] = utils.UserType(acctok['usertype'])
         statInfo = st.statx(acctok['endpoint'], acctok['filename'], acctok['userid'])
+
         # populate metadata for this file
         fmd = {}
         fmd['BaseFileName'] = fmd['BreadcrumbDocName'] = os.path.basename(acctok['filename'])
@@ -77,7 +78,7 @@ def checkFileInfo(fileid, acctok):
         if acctok['viewmode'] != utils.ViewMode.VIEW_ONLY and srv.config.get('general', 'downloadurl', fallback=None):
             fmd['DownloadUrl'] = fmd['FileUrl'] = '%s?access_token=%s' % \
                                                   (srv.config.get('general', 'downloadurl'), flask.request.args['access_token'])
-        if srv.config.get('general', 'businessflow', fallback='True').upper() == 'TRUE':
+        if srv.config.get('apps', 'businessflow', fallback='True').upper() == 'TRUE':
             # according to Microsoft, this must be enabled for all users
             fmd['LicenseCheckForEditIsEnabled'] = True
         fmd['BreadcrumbBrandName'] = srv.config.get('general', 'brandingname', fallback=None)
@@ -105,11 +106,11 @@ def checkFileInfo(fileid, acctok):
         uinfo = statInfo['xattrs'].get(utils.USERINFOKEY + '.' + acctok['wopiuser'].split('!')[0])
         if uinfo:
             fmd['UserInfo'] = uinfo
-        if srv.config.get('general', 'earlyfeatures', fallback='False').upper() == 'TRUE':
-            fmd['AllowEarlyFeatures'] = True
-        fmd['ComplianceDomainPrefix'] = srv.config.get('general', 'compliancedomain', fallback='euc')
 
         # populate app-specific metadata
+        if srv.config.get('apps', 'earlyfeatures', fallback='False').upper() == 'TRUE':
+            fmd['AllowEarlyFeatures'] = True
+        fmd['ComplianceDomainPrefix'] = srv.config.get('apps', 'compliancedomain', fallback='euc')
         # the following is to enable the 'Edit in Word/Excel/PowerPoint' (desktop) action (probably broken)
         try:
             fmd['ClientUrl'] = srv.config.get('general', 'webdavurl') + '/' + acctok['filename']

--- a/src/core/wopiutils.py
+++ b/src/core/wopiutils.py
@@ -229,7 +229,7 @@ def generateAccessToken(userid, fileid, viewmode, user, folderurl, endpoint, app
     exptime = int(time.time()) + srv.config.getint('general', 'tokenvalidity')
     fname = statinfo['filepath']
     fext = os.path.splitext(fname)[1].lower()
-    if appname != 'Collabora' and viewmode == ViewMode.READ_WRITE and (
+    if 'Collabora' not in appname and viewmode == ViewMode.READ_WRITE and (
             fext in ('.doc', '.dot', '.xls', '.ppt', '.pps', '.csv') or
             fext[1:3] in ('od', 'ot') and srv.config.get('general', 'disablemswriteodf', fallback='False').upper() == 'TRUE'):
         # we're opening a legacy format file or an ODF (`.o[d|t]?`) and the app is not Collabora

--- a/src/wopiserver.py
+++ b/src/wopiserver.py
@@ -124,10 +124,10 @@ class Wopi:
             # prepare the Flask web app
             cls.port = int(cls.config.get('general', 'port'))
             try:
-                cls.nonofficetypes = cls.config.get('general', 'nonofficetypes').split()
+                cls.nonofficetypes = cls.config.get('apps', 'nonofficetypes').split()
             except (TypeError, configparser.NoOptionError):
                 cls.nonofficetypes = []
-            cls.codetypes = cls.config.get('general', 'codeofficetypes', fallback='.odt .ods .odp').split()
+            cls.codetypes = cls.config.get('apps', 'codeofficetypes', fallback='.odt .ods .odp').split()
             with open(cls.config.get('security', 'wopisecretfile')) as s:
                 cls.wopisecret = s.read().strip('\n')
             with open(cls.config.get('security', 'iopsecretfile')) as s:
@@ -366,7 +366,7 @@ def iopOpenInApp():
         res['app-url'] = appurl if vm == utils.ViewMode.READ_WRITE else appviewurl
         res['app-url'] += '%sWOPISrc=%s' % ('&' if '?' in res['app-url'] else '?',
                                             utils.generateWopiSrc(inode, appname == Wopi.proxiedappname))
-        if Wopi.config.get('general', 'businessflow', fallback='False').upper() == 'TRUE':
+        if Wopi.config.get('apps', 'businessflow', fallback='False').upper() == 'TRUE':
             # tells the app to enable the business flow if appropriate
             res['app-url'] += '&IsLicensedUser=1'
         res['form-parameters'] = {'access_token': acctok}

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -72,13 +72,6 @@ loghandler = file
 # Optional URL to a privacy notice for this service
 #privacyurl = https://your-organization/path/to/privacy-notice
 
-# List of file extensions deemed incompatible with LibreOffice:
-# interoperable locking will be disabled for such files
-nonofficetypes = .md .zmd .txt
-
-# List of file extensions supported by Collabora
-codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .xlm .ppt .pot .pps .vsd .dxf .wmf .cdr .pages .number .key
-
 # WOPI access token expiration time [seconds]
 #tokenvalidity = 86400
 
@@ -133,6 +126,14 @@ codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .x
 #wopiproxy = https://external-wopi-proxy.com
 #wopiproxysecretfile = /path/to/your/shared-key-file
 #proxiedappname = Name of your proxied app
+
+[apps]
+# List of file extensions deemed incompatible with LibreOffice:
+# interoperable locking will be disabled for such files
+nonofficetypes = .md .zmd .txt
+
+# List of file extensions supported by Collabora
+codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .xlm .ppt .pot .pps .vsd .dxf .wmf .cdr .pages .number .key
 
 # A flag to disable the business flow with Microsoft Office 365 as detailed in:
 # https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/scenarios/business

--- a/wopiserver.conf
+++ b/wopiserver.conf
@@ -148,6 +148,8 @@ codeofficetypes = .odt .ott .ods .ots .odp .otp .odg .otg .doc .dot .xls .xlt .x
 # A flag to enable early features with Microsoft Office
 #earlyfeatures = False
 
+# A flag to disable 'Export As' in Collabora Online
+#codedisableexport = False
 
 [security]
 # Location of the secret files. Requires a restart of the


### PR DESCRIPTION
This is to allow disabling `Export As...` in Collabora, until we can properly support it. Supersedes #177 